### PR TITLE
[Consensus] Complete Shadow finality and epoch protocol

### DIFF
--- a/.github/workflows/shadow-model.yml
+++ b/.github/workflows/shadow-model.yml
@@ -1,0 +1,25 @@
+name: Shadow model
+
+on:
+  pull_request:
+    paths:
+      - "spec/consensus/**"
+      - "headers/consensus/**"
+      - "sources/consensus/**"
+      - "scripts/check_shadow_model.sh"
+      - ".github/workflows/shadow-model.yml"
+  push:
+    branches:
+      - dev
+      - boost/core-dev-1.0
+
+jobs:
+  model:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: bash scripts/check_shadow_model.sh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -163,6 +163,9 @@ set(EXTRACHAIN_CORE_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/headers/contracts/wasm_runtime.h
     ${CMAKE_CURRENT_LIST_DIR}/headers/contracts/toolchain_registry.h
     ${CMAKE_CURRENT_LIST_DIR}/headers/consensus/consensus_engine.h
+    ${CMAKE_CURRENT_LIST_DIR}/headers/consensus/consensus_protocol.h
+    ${CMAKE_CURRENT_LIST_DIR}/headers/consensus/intent_store.h
+    ${CMAKE_CURRENT_LIST_DIR}/headers/consensus/light_client.h
     ${CMAKE_CURRENT_LIST_DIR}/headers/consensus/consensus_service.h
     ${CMAKE_CURRENT_LIST_DIR}/headers/consensus/consensus_types.h
     ${CMAKE_CURRENT_LIST_DIR}/headers/consensus/peer_authenticator.h
@@ -236,6 +239,9 @@ set(EXTRACHAIN_CORE_SOURCES
     ${CMAKE_CURRENT_LIST_DIR}/sources/chat/message.cpp
     ${CMAKE_CURRENT_LIST_DIR}/sources/contracts/wasm_runtime.cpp
     ${CMAKE_CURRENT_LIST_DIR}/sources/consensus/consensus_engine.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/sources/consensus/consensus_protocol.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/sources/consensus/intent_store.cpp
+    ${CMAKE_CURRENT_LIST_DIR}/sources/consensus/light_client.cpp
     ${CMAKE_CURRENT_LIST_DIR}/sources/consensus/consensus_service.cpp
     ${CMAKE_CURRENT_LIST_DIR}/sources/consensus/consensus_types.cpp
     ${CMAKE_CURRENT_LIST_DIR}/sources/consensus/peer_authenticator.cpp

--- a/headers/chain/dag.h
+++ b/headers/chain/dag.h
@@ -48,6 +48,9 @@
 namespace ExtraChain::Core {
     class ExtraChainNode;
 }
+namespace ExtraChain::Consensus {
+    struct IntentEnvelope;
+}
 class Responder;
 
 // Control hashes live on every CONTROL_INTERVAL-th section (section_id % 20 == 0).
@@ -607,6 +610,16 @@ public:
     std::optional<Section> read_section(const SectionId &section_id) const;
     std::expected<ExtraChain::Consensus::SectionBatchData, ExtraChain::Consensus::ConsensusError>
     build_shadow_batch(const SectionId &first_section, const SectionId &last_section, std::string header_hash);
+    std::expected<ExtraChain::Consensus::SectionBatchData, ExtraChain::Consensus::ConsensusError>
+    build_shadow_intent_batch(const SectionId                                          &first_section,
+                              const SectionId                                          &last_section,
+                              std::uint64_t                                             logical_time,
+                              const std::vector<ExtraChain::Consensus::IntentEnvelope> &intents,
+                              std::string                                               header_hash,
+                              std::optional<std::string> previous_section_bytes = std::nullopt,
+                              std::string                previous_section_root  = {});
+    std::expected<std::string, ExtraChain::Consensus::ConsensusError> shadow_batch_section_root(
+        const ExtraChain::Consensus::SectionBatchData &batch) const;
     std::expected<void, ExtraChain::Consensus::ConsensusError> validate_shadow_batch(
         const ExtraChain::Consensus::Proposal         &proposal,
         const ExtraChain::Consensus::SectionBatchData &batch,
@@ -810,7 +823,8 @@ private:
                                                                             const std::set<Transaction>           *pending_transactions,
                                                                             const std::unordered_set<std::string> *pending_hashes,
                                                                             const SectionId                       *validation_frontier,
-                                                                            const TransactionValidationFacts      *facts);
+                                                                            const TransactionValidationFacts      *facts,
+                                                                            bool stage_contract_change);
 
     StatusEvent                                           status_event_;
     SyncStartEvent                                        sync_start_event_;
@@ -1153,8 +1167,9 @@ public:
      */
     TransactionProveError prove_transaction(const Transaction           &tx,
                                             const std::set<Transaction> &transactions,
-                                            const std::set<Transaction> *pending_transactions = nullptr,
-                                            const SectionId             *validation_frontier  = nullptr);
+                                            const std::set<Transaction> *pending_transactions  = nullptr,
+                                            const SectionId             *validation_frontier   = nullptr,
+                                            bool                         stage_contract_change = true);
 
     void clear_dag();
     void clear_dag_folder();

--- a/headers/chain/transaction.h
+++ b/headers/chain/transaction.h
@@ -39,6 +39,7 @@ enum class TransactionType {
     ContractCall    = 9,  ///< Execute a WebAssembly contract method
     ContractUpgrade = 10, ///< Activate a new immutable contract version
     TokenMigration  = 11, ///< Schedule deterministic legacy-token migration
+    EpochChange     = 12, ///< Activate a governed Shadow validator epoch
     Balance         = 99, ///< Balance query transaction
     Unknown         = 100 ///< Unrecognized transaction type
 };
@@ -53,6 +54,10 @@ constexpr bool is_token_migration_transaction(TransactionType type) {
     return type == TransactionType::TokenMigration;
 }
 
+constexpr bool is_epoch_change_transaction(TransactionType type) {
+    return type == TransactionType::EpochChange;
+}
+
 /**
  * @brief Transaction processing error codes
  */
@@ -65,7 +70,8 @@ enum class TransactionError {
     NoCurrentUser,     ///< No active user context
     ZeroAmount,        ///< Transaction amount is zero
     SubscriptionRowFull,
-    NotReady ///< Chain view is stale (still syncing) — the section stamp would be wrong
+    NotReady,      ///< Chain view is stale (still syncing) — the section stamp would be wrong
+    IntentRequired ///< Shadow requires TransactionIntentV2 for new operations
 };
 
 /**
@@ -115,7 +121,8 @@ enum class TransactionProveError {
     TokenMigrationInvalid,
     TokenMigrationFrozen,
     AdmissionBusy,
-    StateUnavailable
+    StateUnavailable,
+    IntentRequired ///< Legacy transaction arrived after the V2 activation point
 };
 
 /**
@@ -126,17 +133,18 @@ enum class TransactionProveError {
  */
 class EXTRACHAIN_EXPORT Transaction {
 private:
-    ActorId                    sender_;     ///< Transaction sender address
-    ActorId                    receiver_;   ///< Transaction receiver address
-    BigNumberFloat             amount_;     ///< Transaction amount
-    std::optional<std::string> meta_;       ///< Optional metadata payload
-    ActorId                    token_;      ///< Token contract address
-    SectionId                  section_;    ///< Chain section ID
-    std::string                hash_;       ///< Transaction hash (Blake3)
-    Signature                  signature_;  ///< Digital signature
-    TransactionType            type_;       ///< Transaction type
-    std::uint64_t              timestamp_;  ///< Creation timestamp
-    std::set<std::string>      prev_hashs_; ///< Previous transaction hashes
+    ActorId                    sender_;           ///< Transaction sender address
+    ActorId                    receiver_;         ///< Transaction receiver address
+    BigNumberFloat             amount_;           ///< Transaction amount
+    std::optional<std::string> meta_;             ///< Optional metadata payload
+    std::optional<std::string> consensus_intent_; ///< Signed V2 intent encoded as Base64 MessagePack
+    ActorId                    token_;            ///< Token contract address
+    SectionId                  section_;          ///< Chain section ID
+    std::string                hash_;             ///< Transaction hash (Blake3)
+    Signature                  signature_;        ///< Digital signature
+    TransactionType            type_;             ///< Transaction type
+    std::uint64_t              timestamp_;        ///< Creation timestamp
+    std::set<std::string>      prev_hashs_;       ///< Previous transaction hashes
 
     // Shared preimage for calculate_hash()/calculate_hash_hex(); hex=true encodes
     // section/amount in the legacy hex form. Single source so the two can't desync.
@@ -203,6 +211,12 @@ public:
      * @return Optional metadata string
      */
     std::optional<std::string> meta() const;
+
+    /**
+     * @brief Get the stable consensus intent used to authorize this transaction
+     * @return Base64 MessagePack envelope for V2 transactions, or no value for historical V1 data
+     */
+    [[nodiscard]] const std::optional<std::string> &consensus_intent() const noexcept;
 
     /**
      * @brief Get transaction hash
@@ -352,6 +366,13 @@ public:
     void set_meta(const std::string &value);
 
     /**
+     * @brief Bind a signed V2 intent to the deterministic DAG materialization
+     * @param payload Base64 MessagePack IntentEnvelope
+     * @param signature Raw Ed25519 signature copied from the intent
+     */
+    void set_consensus_intent(std::string payload, Signature signature);
+
+    /**
      * @brief Set previous transaction hashes
      * @param prev_hashs Set of hash strings
      */
@@ -365,12 +386,22 @@ public:
         this->prev_hashs_.insert(hash);
     }
 
-    BOOST_DESCRIBE_CLASS(
-        Transaction,
-        (),
-        (),
-        (),
-        (section_, type_, sender_, receiver_, token_, amount_, timestamp_, meta_, prev_hashs_, hash_, signature_))
+    BOOST_DESCRIBE_CLASS(Transaction,
+                         (),
+                         (),
+                         (),
+                         (section_,
+                          type_,
+                          sender_,
+                          receiver_,
+                          token_,
+                          amount_,
+                          timestamp_,
+                          meta_,
+                          prev_hashs_,
+                          hash_,
+                          signature_,
+                          consensus_intent_))
 };
 
 /**

--- a/headers/consensus/consensus_engine.h
+++ b/headers/consensus/consensus_engine.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <expected>
+#include <atomic>
 #include <functional>
 #include <map>
 #include <mutex>
@@ -18,6 +19,7 @@
 #include <string>
 #include <unordered_set>
 
+#include "consensus/consensus_protocol.h"
 #include "consensus/safety_store.h"
 #include "consensus/validator_set.h"
 
@@ -40,7 +42,8 @@ namespace ExtraChain::Consensus {
         ConsensusEngine(ValidatorSetView                 validators,
                         std::optional<ValidatorIdentity> identity,
                         std::unique_ptr<SafetyStore>     store,
-                        ProposalValidator                proposal_validator = {});
+                        ProposalValidator                proposal_validator = {},
+                        std::optional<EpochBootstrapV1>  epoch_bootstrap    = std::nullopt);
 
         std::expected<void, ConsensusError>           initialize();
         std::expected<Proposal, ConsensusError>       make_proposal(SectionBatchManifest batch,
@@ -64,13 +67,18 @@ namespace ExtraChain::Consensus {
             std::size_t   limit) const;
         [[nodiscard]] std::expected<std::optional<FinalityProof>, ConsensusError> finality_proof_for_section(
             std::uint64_t section) const;
+        [[nodiscard]] std::expected<std::optional<TransactionInclusionProofV1>, ConsensusError>
+                           transaction_inclusion_proof(std::string_view transaction_hash) const;
+        [[nodiscard]] bool verify_transaction_inclusion_proof(const TransactionInclusionProofV1& proof) const;
         [[nodiscard]] QuorumCertificate                       genesis_certificate() const;
         [[nodiscard]] const ValidatorSetView&                 validators() const noexcept;
         [[nodiscard]] const SafetyState&                      safety_state() const noexcept;
         [[nodiscard]] const std::optional<ValidatorIdentity>& identity() const noexcept;
+        [[nodiscard]] const std::optional<EpochBootstrapV1>&  epoch_bootstrap() const noexcept;
         [[nodiscard]] bool                    is_local_leader(std::uint64_t height, std::uint64_t round) const;
         [[nodiscard]] std::optional<Proposal> proposal_for(std::string_view header_hash) const;
         [[nodiscard]] std::optional<SectionBatchData> batch_for(std::string_view header_hash) const;
+        [[nodiscard]] ConsensusMetricsSnapshot        metrics() const noexcept;
 
     private:
         [[nodiscard]] bool        verify_proposal(const Proposal& proposal) const;
@@ -90,6 +98,7 @@ namespace ExtraChain::Consensus {
         std::optional<ValidatorIdentity>                          identity_;
         std::unique_ptr<SafetyStore>                              store_;
         ProposalValidator                                         proposal_validator_;
+        std::optional<EpochBootstrapV1>                           epoch_bootstrap_;
         SafetyState                                               safety_state_;
         std::map<std::string, Proposal>                           proposals_;
         std::map<std::string, SectionBatchData>                   batches_;
@@ -103,6 +112,13 @@ namespace ExtraChain::Consensus {
         std::unordered_set<std::string>                           certified_headers_;
         mutable std::recursive_mutex                              mutex_;
         bool                                                      initialized_ = false;
+        std::atomic<std::uint64_t>                                proposals_created_ { 0 };
+        std::atomic<std::uint64_t>                                batches_staged_ { 0 };
+        std::atomic<std::uint64_t>                                votes_created_ { 0 };
+        std::atomic<std::uint64_t>                                timeout_votes_created_ { 0 };
+        std::atomic<std::uint64_t>                                certificates_accepted_ { 0 };
+        std::atomic<std::uint64_t>                                checkpoints_finalized_ { 0 };
+        std::atomic<std::uint64_t>                                stage_nanoseconds_ { 0 };
     };
 
 } // namespace ExtraChain::Consensus

--- a/headers/consensus/consensus_protocol.h
+++ b/headers/consensus/consensus_protocol.h
@@ -1,0 +1,398 @@
+/*
+ * ExtraChain Core
+ * Copyright (C) 2025 ExtraChain Foundation <official@extrachain.io>
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, Inc., either version 3 of the License,
+ * or (at your option) any later version.
+ */
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <expected>
+#include <map>
+#include <optional>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "consensus/consensus_types.h"
+
+class Transaction;
+
+namespace ExtraChain::Consensus {
+
+    inline constexpr std::size_t   ShadowCommitteeSize   = 7;
+    inline constexpr std::size_t   GovernanceSignerCount = 5;
+    inline constexpr std::uint16_t GovernanceThreshold   = 3;
+    inline constexpr std::uint16_t RecoveryThreshold     = 4;
+
+    enum class IntentOperation : std::uint8_t {
+        Transfer,
+        ContractDeploy,
+        ContractCall,
+        ContractUpgrade,
+        TokenMigration,
+        EpochChange
+    };
+
+    enum class IntentStatus : std::uint8_t {
+        Accepted,
+        Certified,
+        Finalized,
+        Rejected,
+        Expired
+    };
+
+    struct TransactionIntentV2 {
+        std::uint16_t   protocol_version = ProtocolVersion;
+        ActorId         network_id;
+        ActorId         sender;
+        ActorId         receiver;
+        ActorId         token;
+        std::string     amount;
+        IntentOperation operation = IntentOperation::Transfer;
+        std::string     metadata_hash;
+        std::uint64_t   account_nonce        = 0;
+        std::uint64_t   valid_after_height   = 0;
+        std::uint64_t   expires_after_height = 0;
+        std::string     signature;
+
+        MSGPACK_DEFINE(protocol_version,
+                       network_id,
+                       sender,
+                       receiver,
+                       token,
+                       amount,
+                       operation,
+                       metadata_hash,
+                       account_nonce,
+                       valid_after_height,
+                       expires_after_height,
+                       signature)
+    };
+
+    struct IntentEnvelope {
+        TransactionIntentV2 intent;
+        std::string         metadata;
+
+        MSGPACK_DEFINE(intent, metadata)
+    };
+
+    struct IntentReceipt {
+        std::string    intent_hash;
+        IntentStatus   status           = IntentStatus::Accepted;
+        std::uint64_t  consensus_height = 0;
+        std::uint64_t  dag_section      = 0;
+        std::uint32_t  position         = 0;
+        ConsensusError error            = ConsensusError::NotReady;
+
+        MSGPACK_DEFINE(intent_hash, status, consensus_height, dag_section, position, error)
+    };
+
+    struct MerkleProof {
+        std::uint64_t            leaf_index = 0;
+        std::uint64_t            leaf_count = 0;
+        std::string              leaf_hash;
+        std::vector<std::string> siblings;
+
+        MSGPACK_DEFINE(leaf_index, leaf_count, leaf_hash, siblings)
+    };
+
+    struct IndexedSignature {
+        std::uint16_t signer_index = 0;
+        std::string   signature;
+
+        MSGPACK_DEFINE(signer_index, signature)
+    };
+
+    struct MultisigPolicy {
+        std::uint16_t            protocol_version = ProtocolVersion;
+        ActorId                  network_id;
+        std::uint16_t            threshold = 0;
+        std::vector<std::string> public_keys;
+        std::string              policy_hash;
+
+        MSGPACK_DEFINE(protocol_version, network_id, threshold, public_keys, policy_hash)
+    };
+
+    struct GovernanceAuthorization {
+        std::uint16_t                 protocol_version = ProtocolVersion;
+        ActorId                       network_id;
+        std::uint64_t                 sequence = 0;
+        std::string                   action_hash;
+        std::vector<IndexedSignature> signatures;
+
+        MSGPACK_DEFINE(protocol_version, network_id, sequence, action_hash, signatures)
+    };
+
+    struct OperatorAttestation {
+        std::string   operator_id_hash;
+        ActorId       actor_id;
+        std::string   node_identifier;
+        std::string   consensus_public_key;
+        std::string   document_hash;
+        std::uint32_t policy_version = 1;
+
+        MSGPACK_DEFINE(operator_id_hash,
+                       actor_id,
+                       node_identifier,
+                       consensus_public_key,
+                       document_hash,
+                       policy_version)
+    };
+
+    struct EpochChangeV1 {
+        std::uint16_t                    protocol_version = ProtocolVersion;
+        ActorId                          network_id;
+        std::uint64_t                    current_epoch     = 0;
+        std::uint64_t                    activation_epoch  = 0;
+        std::uint64_t                    activation_height = 0;
+        std::string                      current_validator_set_hash;
+        std::string                      next_validator_set_hash;
+        std::string                      registry_document_hash;
+        std::vector<OperatorAttestation> operators;
+        GovernanceAuthorization          authorization;
+
+        MSGPACK_DEFINE(protocol_version,
+                       network_id,
+                       current_epoch,
+                       activation_epoch,
+                       activation_height,
+                       current_validator_set_hash,
+                       next_validator_set_hash,
+                       registry_document_hash,
+                       operators,
+                       authorization)
+    };
+
+    struct EpochBootstrapV1 {
+        std::uint16_t protocol_version = ProtocolVersion;
+        ActorId       network_id;
+        std::uint64_t previous_epoch            = 0;
+        std::uint64_t epoch                     = 0;
+        std::uint64_t activation_height         = 0;
+        std::uint64_t previous_finalized_height = 0;
+        std::uint64_t first_dag_section         = 0;
+        std::string   previous_section_root;
+        std::string   previous_state_commitment;
+        std::string   previous_decision_certificate_hash;
+        std::string   epoch_change_hash;
+        std::string   validator_set_hash;
+
+        MSGPACK_DEFINE(protocol_version,
+                       network_id,
+                       previous_epoch,
+                       epoch,
+                       activation_height,
+                       previous_finalized_height,
+                       first_dag_section,
+                       previous_section_root,
+                       previous_state_commitment,
+                       previous_decision_certificate_hash,
+                       epoch_change_hash,
+                       validator_set_hash)
+    };
+
+    struct EpochChangeRequestV1 {
+        std::uint16_t protocol_version = ProtocolVersion;
+        EpochChangeV1 change;
+        ValidatorSet  next_validators;
+
+        MSGPACK_DEFINE(protocol_version, change, next_validators)
+    };
+
+    struct RecoveryDocumentV1 {
+        std::uint16_t           protocol_version = ProtocolVersion;
+        ActorId                 network_id;
+        std::uint64_t           recovery_sequence = 0;
+        std::uint64_t           finalized_height  = 0;
+        std::string             finalized_checkpoint_hash;
+        std::string             next_validator_set_hash;
+        std::string             registry_document_hash;
+        GovernanceAuthorization authorization;
+
+        MSGPACK_DEFINE(protocol_version,
+                       network_id,
+                       recovery_sequence,
+                       finalized_height,
+                       finalized_checkpoint_hash,
+                       next_validator_set_hash,
+                       registry_document_hash,
+                       authorization)
+    };
+
+    struct ActivationManifestV1 {
+        std::uint16_t           protocol_version = ProtocolVersion;
+        ActorId                 network_id;
+        std::uint64_t           activation_height      = 0;
+        std::uint64_t           activation_dag_section = 0;
+        std::string             validator_set_hash;
+        bool                    require_intent_v2 = true;
+        GovernanceAuthorization authorization;
+
+        MSGPACK_DEFINE(protocol_version,
+                       network_id,
+                       activation_height,
+                       activation_dag_section,
+                       validator_set_hash,
+                       require_intent_v2,
+                       authorization)
+    };
+
+    struct StateCommitmentV2 {
+        std::uint16_t protocol_version = ProtocolVersion;
+        ActorId       network_id;
+        std::uint64_t epoch  = 0;
+        std::uint64_t height = 0;
+        std::string   previous_state_commitment;
+        std::string   section_root;
+        std::string   account_state_root;
+        std::string   contract_state_root;
+        std::string   token_registry_root;
+        std::string   validator_set_hash;
+
+        MSGPACK_DEFINE(protocol_version,
+                       network_id,
+                       epoch,
+                       height,
+                       previous_state_commitment,
+                       section_root,
+                       account_state_root,
+                       contract_state_root,
+                       token_registry_root,
+                       validator_set_hash)
+    };
+
+    struct TransactionInclusionProofV1 {
+        std::uint16_t protocol_version = ProtocolVersion;
+        ActorId       network_id;
+        std::uint64_t epoch  = 0;
+        std::uint64_t height = 0;
+        std::string   transaction_hash;
+        MerkleProof   merkle_proof;
+        FinalityProof finality_proof;
+
+        MSGPACK_DEFINE(protocol_version, network_id, epoch, height, transaction_hash, merkle_proof, finality_proof)
+    };
+
+    struct EpochTransitionV1 {
+        std::uint16_t               protocol_version = ProtocolVersion;
+        EpochChangeV1               change;
+        ValidatorSet                next_validators;
+        TransactionInclusionProofV1 proof;
+        EpochBootstrapV1            bootstrap;
+
+        MSGPACK_DEFINE(protocol_version, change, next_validators, proof, bootstrap)
+    };
+
+    struct IntentPoolLimits {
+        std::size_t   maximum_intents        = 16'384;
+        std::size_t   maximum_bytes          = 64ULL * 1024ULL * 1024ULL;
+        std::size_t   maximum_sender_intents = 64;
+        std::uint64_t maximum_nonce_gap      = 64;
+        std::size_t   maximum_metadata_bytes = 256ULL * 1024ULL;
+    };
+
+    class EXTRACHAIN_EXPORT IntentPool {
+    public:
+        explicit IntentPool(IntentPoolLimits limits = {});
+
+        std::expected<std::string, ConsensusError> submit(const IntentEnvelope& envelope,
+                                                          std::string_view      sender_public_key,
+                                                          std::uint64_t         committed_nonce,
+                                                          std::uint64_t         current_height);
+        [[nodiscard]] std::vector<IntentEnvelope>  ready(const std::map<ActorId, std::uint64_t>& committed_nonces,
+                                                         std::uint64_t                           current_height,
+                                                         std::size_t                             maximum_count,
+                                                         std::size_t maximum_bytes) const;
+        std::vector<std::string>                   expire(std::uint64_t current_height);
+        void                                       erase(const std::vector<std::string>& intent_hashes);
+
+        [[nodiscard]] std::size_t size() const noexcept;
+        [[nodiscard]] std::size_t bytes() const noexcept;
+
+    private:
+        struct Entry {
+            IntentEnvelope envelope;
+            std::size_t    bytes = 0;
+        };
+
+        IntentPoolLimits               limits_;
+        std::map<std::string, Entry>   entries_;
+        std::map<ActorId, std::size_t> sender_counts_;
+        std::size_t                    bytes_ = 0;
+    };
+
+    EXTRACHAIN_EXPORT std::string intent_metadata_hash(std::string_view metadata);
+    EXTRACHAIN_EXPORT std::string intent_signing_payload(const TransactionIntentV2& intent);
+    EXTRACHAIN_EXPORT std::string hash_intent(const TransactionIntentV2& intent);
+    EXTRACHAIN_EXPORT std::expected<TransactionIntentV2, ConsensusError> make_intent(
+        TransactionIntentV2      intent,
+        std::string_view         metadata,
+        const Actor<KeyPrivate>& sender);
+    EXTRACHAIN_EXPORT bool verify_intent(const IntentEnvelope& envelope, std::string_view sender_public_key);
+    EXTRACHAIN_EXPORT std::expected<Transaction, ConsensusError> materialize_intent(
+        const IntentEnvelope&        envelope,
+        std::uint64_t                section,
+        std::uint64_t                logical_time,
+        const std::set<std::string>& previous_hashes);
+    EXTRACHAIN_EXPORT std::expected<IntentEnvelope, ConsensusError> intent_from_transaction(
+        const Transaction& transaction);
+    EXTRACHAIN_EXPORT bool verify_materialized_intent(const Transaction& transaction,
+                                                      std::string_view   sender_public_key);
+    EXTRACHAIN_EXPORT std::string consensus_transaction_hash(const Transaction& transaction);
+
+    EXTRACHAIN_EXPORT std::string merkle_root(const std::vector<std::string>& values);
+    EXTRACHAIN_EXPORT std::expected<MerkleProof, ConsensusError> make_merkle_proof(
+        const std::vector<std::string>& values,
+        std::size_t                     index);
+    EXTRACHAIN_EXPORT bool verify_merkle_proof(std::string_view   value,
+                                               const MerkleProof& proof,
+                                               std::string_view   expected_root);
+
+    EXTRACHAIN_EXPORT std::expected<MultisigPolicy, ConsensusError> make_multisig_policy(
+        const ActorId&           network_id,
+        std::uint16_t            threshold,
+        std::vector<std::string> public_keys);
+    EXTRACHAIN_EXPORT bool verify_multisig_policy(const MultisigPolicy& policy);
+    EXTRACHAIN_EXPORT std::expected<GovernanceAuthorization, ConsensusError> authorize_action(
+        const MultisigPolicy&          policy,
+        std::uint64_t                  sequence,
+        std::string                    action_hash,
+        const std::vector<KeyPrivate>& signers);
+    EXTRACHAIN_EXPORT bool verify_authorization(const MultisigPolicy&          policy,
+                                                const GovernanceAuthorization& authorization,
+                                                std::uint64_t                  minimum_sequence);
+    EXTRACHAIN_EXPORT std::string epoch_change_action_hash(const EpochChangeV1& change);
+    EXTRACHAIN_EXPORT bool        verify_epoch_change(const EpochChangeV1&  change,
+                                                      const MultisigPolicy& policy,
+                                                      std::uint64_t         current_height,
+                                                      std::uint64_t         minimum_sequence);
+    EXTRACHAIN_EXPORT std::expected<EpochBootstrapV1, ConsensusError> make_epoch_bootstrap(
+        const EpochChangeV1&               change,
+        const ValidatorSet&                next_validators,
+        const TransactionInclusionProofV1& proof);
+    EXTRACHAIN_EXPORT std::string hash_epoch_bootstrap(const EpochBootstrapV1& bootstrap);
+    EXTRACHAIN_EXPORT bool        verify_epoch_bootstrap(const EpochBootstrapV1& bootstrap,
+                                                         const ValidatorSet&     next_validators);
+    EXTRACHAIN_EXPORT std::string recovery_action_hash(const RecoveryDocumentV1& recovery);
+    EXTRACHAIN_EXPORT bool        verify_recovery_document(const RecoveryDocumentV1& recovery,
+                                                           const MultisigPolicy&     recovery_policy,
+                                                           std::uint64_t             expected_sequence,
+                                                           std::uint64_t             expected_finalized_height,
+                                                           std::string_view          expected_checkpoint_hash);
+    EXTRACHAIN_EXPORT std::string activation_action_hash(const ActivationManifestV1& activation);
+    EXTRACHAIN_EXPORT bool        verify_activation_manifest(const ActivationManifestV1& activation,
+                                                             const MultisigPolicy&       policy,
+                                                             std::uint64_t               current_height,
+                                                             std::uint64_t               minimum_sequence);
+    EXTRACHAIN_EXPORT std::string hash_state_commitment(const StateCommitmentV2& commitment);
+
+} // namespace ExtraChain::Consensus
+
+MSGPACK_ADD_ENUM(ExtraChain::Consensus::IntentOperation)
+MSGPACK_ADD_ENUM(ExtraChain::Consensus::IntentStatus)

--- a/headers/consensus/consensus_service.h
+++ b/headers/consensus/consensus_service.h
@@ -15,11 +15,13 @@
 #include <map>
 #include <mutex>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include <boost/signals2/connection.hpp>
 
 #include "consensus/peer_authenticator.h"
+#include "consensus/intent_store.h"
 #include "consensus/shadow_consensus.h"
 #include "runtime/event.h"
 #include "runtime/deadline_task.h"
@@ -66,11 +68,25 @@ namespace ExtraChain::Consensus {
                                   const Responder&         responder,
                                   std::string_view         peer_identifier);
         void receive_sync_response(const ShadowSyncResponse& response, std::string_view peer_identifier);
+        void receive_intent(const IntentEnvelope& envelope);
 
-        [[nodiscard]] bool                                     active() const noexcept;
-        [[nodiscard]] bool                                     voting() const noexcept;
-        [[nodiscard]] bool                                     controls_section(std::uint64_t section) const;
-        bool                                                   repair_section(std::uint64_t section);
+        std::expected<std::string, ConsensusError> submit_intent(const IntentEnvelope& envelope);
+        [[nodiscard]] std::vector<IntentEnvelope>  ready_intents(std::size_t maximum_count,
+                                                                 std::size_t maximum_bytes) const;
+        [[nodiscard]] std::expected<std::optional<IntentReceipt>, ConsensusError> intent_receipt(
+            std::string_view intent_hash);
+        std::expected<void, ConsensusError> finalize_intents(
+            const std::vector<std::pair<IntentEnvelope, IntentReceipt>>& finalized);
+
+        [[nodiscard]] bool active() const noexcept;
+        [[nodiscard]] bool voting() const noexcept;
+        [[nodiscard]] bool controls_section(std::uint64_t section) const;
+        [[nodiscard]] bool requires_intent_v2() const noexcept;
+        bool               repair_section(std::uint64_t section);
+        [[nodiscard]] std::expected<std::optional<TransactionInclusionProofV1>, ConsensusError>
+                           transaction_inclusion_proof(std::string_view transaction_hash) const;
+        [[nodiscard]] bool verify_transaction_inclusion_proof(const TransactionInclusionProofV1& proof) const;
+        [[nodiscard]] ConsensusMetricsSnapshot                 metrics() const noexcept;
         [[nodiscard]] Core::Event<const FinalizedCheckpoint&>& finalized_event() noexcept;
 
     private:
@@ -85,6 +101,7 @@ namespace ExtraChain::Consensus {
         void vote_for_proposal(const Proposal& proposal, std::string_view peer_identifier);
         void timeout_elapsed();
         void reset_timeout();
+        void halt_voting();
         void send_to_peer(const auto&        payload,
                           MessageType        message_type,
                           const std::string& identifier,
@@ -92,19 +109,34 @@ namespace ExtraChain::Consensus {
         void send_to_validators(const auto& payload, MessageType message_type);
         void send_to_validators(const auto& payload, MessageType message_type, MessageStatus status);
         [[nodiscard]] std::expected<void, ConsensusError> validate_proposal(const Proposal& proposal);
+        [[nodiscard]] bool                                has_unfinalized_intents() const;
+        std::expected<std::string, ConsensusError> accept_intent(const IntentEnvelope& envelope, bool broadcast);
+        [[nodiscard]] std::expected<std::vector<std::pair<IntentEnvelope, IntentReceipt>>, ConsensusError>
+        finalized_intents(const Proposal& proposal, const SectionBatchData& batch) const;
+        [[nodiscard]] std::expected<void, ConsensusError> admit_batch_intents(const Proposal&         proposal,
+                                                                              const SectionBatchData& batch);
+        std::expected<void, ConsensusError>               process_epoch_changes(
+                          const std::vector<std::pair<IntentEnvelope, IntentReceipt>>& finalized);
+        std::expected<bool, ConsensusError> activate_pending_epoch();
+        [[nodiscard]] std::uint64_t         intent_height() const noexcept;
 
         Core::ExtraChainNode&                           node_;
         std::filesystem::path                           directory_;
         std::unique_ptr<ShadowConsensus>                consensus_;
+        std::unique_ptr<IntentStore>                    intent_store_;
+        IntentPool                                      intent_pool_;
+        std::map<ActorId, std::uint64_t>                committed_nonces_;
         std::unique_ptr<PeerAuthenticator>              authenticator_;
         std::optional<Proposal>                         latest_proposal_;
         std::optional<QuorumCertificate>                latest_certificate_;
         std::optional<TimeoutCertificate>               latest_timeout_certificate_;
         std::map<std::uint64_t, ShadowCheckpoint>       pending_checkpoints_;
+        std::map<std::uint64_t, SectionBatchData>       pending_batches_;
         std::map<std::string, Proposal>                 pending_proposals_;
         std::shared_ptr<Core::DeadlineTask>             timeout_task_;
         std::vector<boost::signals2::scoped_connection> connections_;
         Core::Event<const FinalizedCheckpoint&>         finalized_event_;
+        bool                                            voting_enabled_ = false;
         mutable std::recursive_mutex                    mutex_;
     };
 

--- a/headers/consensus/consensus_types.h
+++ b/headers/consensus/consensus_types.h
@@ -25,7 +25,7 @@
 
 namespace ExtraChain::Consensus {
 
-    inline constexpr std::uint16_t ProtocolVersion         = 2;
+    inline constexpr std::uint16_t ProtocolVersion         = 3;
     inline constexpr std::uint64_t ShadowSectionInterval   = 20;
     inline constexpr std::uint64_t MaximumShadowBatchBytes = 64ULL * 1024ULL * 1024ULL;
     inline constexpr std::uint64_t MaximumShadowSyncBytes  = 32ULL * 1024ULL * 1024ULL;
@@ -71,7 +71,14 @@ namespace ExtraChain::Consensus {
         NotValidator,
         NotLeader,
         NotReady,
-        Replay
+        Replay,
+        InvalidIntent,
+        InvalidNonce,
+        IntentExpired,
+        DuplicateIntent,
+        PoolFull,
+        InvalidProof,
+        InvalidGovernance
     };
 
     struct SectionBatchManifest {
@@ -348,6 +355,16 @@ namespace ExtraChain::Consensus {
         MSGPACK_DEFINE(finalized_proposal, child_proposal, grandchild_proposal, decision_certificate)
     };
 
+    struct ConsensusMetricsSnapshot {
+        std::uint64_t proposals_created = 0;
+        std::uint64_t batches_staged    = 0;
+        std::uint64_t votes_created     = 0;
+        std::uint64_t timeout_votes     = 0;
+        std::uint64_t certificates      = 0;
+        std::uint64_t finalized         = 0;
+        std::uint64_t stage_nanoseconds = 0;
+    };
+
     struct ShadowConfiguration {
         std::uint16_t protocol_version       = ProtocolVersion;
         ShadowMode    mode                   = ShadowMode::Observe;
@@ -438,6 +455,10 @@ namespace ExtraChain::Consensus {
     EXTRACHAIN_EXPORT std::string calculate_data_root(
         const std::vector<std::pair<std::uint64_t, std::string>>& sections);
     EXTRACHAIN_EXPORT std::string hash_certificate(const QuorumCertificate& certificate);
+    EXTRACHAIN_EXPORT std::string calculate_consensus_state_commitment(const QuorumCertificate& parent,
+                                                                       std::string_view         section_root,
+                                                                       std::string_view         batch_root,
+                                                                       std::string_view validator_set_hash);
     EXTRACHAIN_EXPORT std::string hash_timeout_certificate(const TimeoutCertificate& certificate);
     EXTRACHAIN_EXPORT std::string proposal_signing_payload(const Proposal& proposal);
     EXTRACHAIN_EXPORT std::string vote_signing_payload(const Vote& vote);
@@ -458,3 +479,4 @@ namespace ExtraChain::Consensus {
 MSGPACK_ADD_ENUM(ExtraChain::Consensus::ValidatorStatus)
 MSGPACK_ADD_ENUM(ExtraChain::Consensus::Phase)
 MSGPACK_ADD_ENUM(ExtraChain::Consensus::ShadowMode)
+MSGPACK_ADD_ENUM(ExtraChain::Consensus::ConsensusError)

--- a/headers/consensus/intent_store.h
+++ b/headers/consensus/intent_store.h
@@ -1,0 +1,53 @@
+/*
+ * ExtraChain Core
+ * Copyright (C) 2025 ExtraChain Foundation <official@extrachain.io>
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, Inc., either version 3 of the License,
+ * or (at your option) any later version.
+ */
+
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+#include "consensus/consensus_protocol.h"
+
+class DbConnector;
+
+namespace ExtraChain::Consensus {
+
+    class EXTRACHAIN_EXPORT IntentStore {
+    public:
+        explicit IntentStore(std::filesystem::path database_path);
+        ~IntentStore();
+
+        IntentStore(const IntentStore&)            = delete;
+        IntentStore& operator=(const IntentStore&) = delete;
+
+        std::expected<void, ConsensusError> open();
+        std::expected<void, ConsensusError> put(const IntentEnvelope& envelope);
+        std::expected<void, ConsensusError> erase(const std::vector<std::string>& intent_hashes);
+        std::expected<void, ConsensusError> expire(const std::vector<std::string>& intent_hashes);
+        std::expected<std::vector<IntentEnvelope>, ConsensusError>      load_pending();
+        std::expected<std::map<ActorId, std::uint64_t>, ConsensusError> load_committed_nonces();
+        std::expected<void, ConsensusError>                             commit_finalized(
+                                        const std::vector<std::pair<IntentEnvelope, IntentReceipt>>& finalized);
+        std::expected<std::optional<IntentReceipt>, ConsensusError> receipt(std::string_view intent_hash);
+
+    private:
+        std::filesystem::path        database_path_;
+        std::unique_ptr<DbConnector> database_;
+        std::mutex                   mutex_;
+    };
+
+} // namespace ExtraChain::Consensus

--- a/headers/consensus/light_client.h
+++ b/headers/consensus/light_client.h
@@ -1,0 +1,86 @@
+/*
+ * ExtraChain Core
+ * Copyright (C) 2025 ExtraChain Foundation <official@extrachain.io>
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, Inc., either version 3 of the License,
+ * or (at your option) any later version.
+ */
+
+#pragma once
+
+#include <expected>
+#include <filesystem>
+#include <optional>
+
+#include "consensus/validator_set.h"
+
+namespace ExtraChain::Consensus {
+
+    struct LightClientStateV1 {
+        std::uint16_t                    protocol_version = ProtocolVersion;
+        ActorId                          network_id;
+        ValidatorSet                     active_validators;
+        std::optional<EpochBootstrapV1>  active_bootstrap;
+        std::optional<EpochTransitionV1> pending_epoch;
+        std::optional<MultisigPolicy>    pending_policy;
+        std::uint64_t                    pending_minimum_sequence = 0;
+        std::uint64_t                    trusted_epoch            = 0;
+        std::uint64_t                    trusted_height           = 0;
+        std::string                      trusted_header_hash;
+
+        MSGPACK_DEFINE(protocol_version,
+                       network_id,
+                       active_validators,
+                       active_bootstrap,
+                       pending_epoch,
+                       pending_policy,
+                       pending_minimum_sequence,
+                       trusted_epoch,
+                       trusted_height,
+                       trusted_header_hash)
+    };
+
+    class EXTRACHAIN_EXPORT LightClientVerifier {
+    public:
+        static std::expected<LightClientVerifier, ConsensusError> create(
+            ValidatorSet                    trusted_set,
+            std::optional<EpochBootstrapV1> bootstrap = std::nullopt);
+        static std::expected<LightClientVerifier, ConsensusError> restore(LightClientStateV1 state);
+        static std::expected<LightClientVerifier, ConsensusError> load(const std::filesystem::path& path);
+
+        [[nodiscard]] bool                  verify_finality_proof(const FinalityProof& proof) const;
+        std::expected<void, ConsensusError> advance(const FinalityProof& proof);
+        [[nodiscard]] bool verify_transaction_proof(const TransactionInclusionProofV1& proof) const;
+        std::expected<void, ConsensusError>                  schedule_epoch(const EpochChangeV1&               change,
+                                                                            ValidatorSet                       next_set,
+                                                                            const MultisigPolicy&              policy,
+                                                                            const TransactionInclusionProofV1& proof,
+                                                                            std::uint64_t                      minimum_sequence);
+        [[nodiscard]] const ValidatorSetView&                active_validators() const noexcept;
+        [[nodiscard]] const std::optional<ValidatorSetView>& pending_validators() const noexcept;
+        [[nodiscard]] LightClientStateV1                     snapshot() const;
+        std::expected<void, ConsensusError>                  save(const std::filesystem::path& path) const;
+        [[nodiscard]] std::uint64_t                          trusted_height() const noexcept;
+
+    private:
+        explicit LightClientVerifier(ValidatorSetView trusted_set, std::optional<EpochBootstrapV1> bootstrap);
+        [[nodiscard]] const ValidatorSetView* validators_for(std::uint64_t epoch,
+                                                             std::uint64_t height) const noexcept;
+        [[nodiscard]] const EpochBootstrapV1* bootstrap_for(std::uint64_t epoch) const noexcept;
+
+        ValidatorSetView                 active_;
+        std::optional<EpochBootstrapV1>  active_bootstrap_;
+        std::optional<ValidatorSetView>  pending_;
+        std::optional<EpochChangeV1>     pending_change_;
+        std::optional<EpochBootstrapV1>  pending_bootstrap_;
+        std::optional<EpochTransitionV1> pending_transition_;
+        std::optional<MultisigPolicy>    pending_policy_;
+        std::uint64_t                    pending_minimum_sequence_ = 0;
+        std::uint64_t                    trusted_epoch_            = 0;
+        std::uint64_t                    trusted_height_           = 0;
+        std::string                      trusted_header_hash_;
+    };
+
+} // namespace ExtraChain::Consensus

--- a/headers/consensus/shadow_consensus.h
+++ b/headers/consensus/shadow_consensus.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <optional>
 #include <string_view>
+#include <vector>
 
 #include "consensus/consensus_engine.h"
 
@@ -45,6 +46,15 @@ namespace ExtraChain::Consensus {
                                                                        const ValidatorSet&          validators);
         static std::expected<void, ConsensusError> write_configuration(const std::filesystem::path& directory,
                                                                        const ShadowConfiguration&   configuration);
+        static std::expected<void, ConsensusError> write_governance_policy(const std::filesystem::path& directory,
+                                                                           const MultisigPolicy&        policy);
+        static std::expected<void, ConsensusError> write_activation_manifest(
+            const std::filesystem::path& directory,
+            const ActivationManifestV1&  manifest,
+            const MultisigPolicy&        policy);
+        static std::expected<void, ConsensusError> write_epoch_identity(const std::filesystem::path& directory,
+                                                                        std::uint64_t                epoch,
+                                                                        const IdentityDocument&      identity);
 
         std::expected<std::optional<Proposal>, ConsensusError> make_checkpoint_proposal(
             ShadowCheckpoint checkpoint,
@@ -59,18 +69,41 @@ namespace ExtraChain::Consensus {
         std::expected<void, ConsensusError> receive_timeout_certificate(const TimeoutCertificate& certificate);
         std::expected<std::optional<FinalizedCheckpoint>, ConsensusError> receive_certificate(
             const QuorumCertificate& certificate);
+        std::expected<void, ConsensusError>               schedule_epoch(const EpochChangeV1&               change,
+                                                                         ValidatorSet                       next_validators,
+                                                                         const TransactionInclusionProofV1& proof);
+        [[nodiscard]] std::expected<void, ConsensusError> validate_epoch_request(
+            const EpochChangeRequestV1& request,
+            std::uint64_t               proposal_height) const;
+        std::expected<bool, ConsensusError> activate_scheduled_epoch();
 
-        [[nodiscard]] const ConsensusEngine&     engine() const noexcept;
-        [[nodiscard]] ConsensusEngine&           engine() noexcept;
-        [[nodiscard]] const ShadowConfiguration& configuration() const noexcept;
+        [[nodiscard]] const ConsensusEngine&                  engine() const noexcept;
+        [[nodiscard]] ConsensusEngine&                        engine() noexcept;
+        [[nodiscard]] const ShadowConfiguration&              configuration() const noexcept;
+        [[nodiscard]] const std::optional<EpochTransitionV1>& pending_epoch() const noexcept;
 
     private:
-        explicit ShadowConsensus(std::unique_ptr<ConsensusEngine> engine, ShadowConfiguration configuration);
+        explicit ShadowConsensus(std::filesystem::path              directory,
+                                 std::unique_ptr<ConsensusEngine>   engine,
+                                 ShadowConfiguration                configuration,
+                                 std::optional<MultisigPolicy>      governance_policy,
+                                 std::vector<EpochTransitionV1>     epoch_history,
+                                 std::optional<EpochTransitionV1>   pending_epoch,
+                                 std::optional<EpochBootstrapV1>    active_bootstrap,
+                                 std::uint64_t                      minimum_governance_sequence,
+                                 ConsensusEngine::ProposalValidator proposal_validator);
         [[nodiscard]] bool peer_matches_validator(std::string_view validator_id,
                                                   std::string_view peer_identifier) const;
 
-        std::unique_ptr<ConsensusEngine> engine_;
-        ShadowConfiguration              configuration_;
+        std::unique_ptr<ConsensusEngine>   engine_;
+        ShadowConfiguration                configuration_;
+        std::filesystem::path              directory_;
+        std::optional<MultisigPolicy>      governance_policy_;
+        std::vector<EpochTransitionV1>     epoch_history_;
+        std::optional<EpochTransitionV1>   pending_epoch_;
+        std::optional<EpochBootstrapV1>    active_bootstrap_;
+        std::uint64_t                      minimum_governance_sequence_ = 1;
+        ConsensusEngine::ProposalValidator proposal_validator_;
     };
 
 } // namespace ExtraChain::Consensus

--- a/headers/consensus/validator_set.h
+++ b/headers/consensus/validator_set.h
@@ -17,12 +17,26 @@
 #include <vector>
 
 #include "consensus/consensus_types.h"
+#include "consensus/consensus_protocol.h"
 
 namespace ExtraChain::Consensus {
 
     class EXTRACHAIN_EXPORT ValidatorSetView {
     public:
         static std::expected<ValidatorSetView, ConsensusError> create(ValidatorSet validators);
+        static std::expected<ValidatorSetView, ConsensusError> create_governed(
+            ValidatorSet                            validators,
+            std::string                             registry_document_hash,
+            const std::vector<OperatorAttestation>& operators,
+            const MultisigPolicy&                   policy,
+            const GovernanceAuthorization&          authorization,
+            std::uint64_t                           minimum_sequence);
+        static std::expected<ValidatorSetView, ConsensusError> create_epoch_transition(
+            ValidatorSet          validators,
+            const EpochChangeV1&  change,
+            const MultisigPolicy& policy,
+            std::uint64_t         current_height,
+            std::uint64_t         minimum_sequence);
 
         [[nodiscard]] const ValidatorSet&                 document() const noexcept;
         [[nodiscard]] const std::vector<ValidatorRecord>& active() const noexcept;
@@ -55,5 +69,13 @@ namespace ExtraChain::Consensus {
         std::uint64_t                epoch,
         std::vector<ValidatorRecord> validators,
         const Actor<KeyPrivate>&     governance_actor);
+
+    EXTRACHAIN_EXPORT std::string governed_validator_set_action_hash(
+        const ValidatorSet&                     validators,
+        std::string_view                        registry_document_hash,
+        const std::vector<OperatorAttestation>& operators);
+    EXTRACHAIN_EXPORT QuorumCertificate make_genesis_certificate(const ValidatorSetView& validators);
+    EXTRACHAIN_EXPORT QuorumCertificate make_epoch_genesis_certificate(const ValidatorSetView& validators,
+                                                                       const EpochBootstrapV1& bootstrap);
 
 } // namespace ExtraChain::Consensus

--- a/headers/core/extrachain_node.h
+++ b/headers/core/extrachain_node.h
@@ -349,7 +349,8 @@ namespace ExtraChain::Core {
             Transaction                                   transaction,
             const Actor<KeyPrivate>&                      signer,
             ExtraChain::Contracts::PreparedContractChange change);
-        TransactionProveError validate_contract_transaction(const Transaction& transaction);
+        TransactionProveError validate_contract_transaction(const Transaction& transaction,
+                                                            bool               stage_change = true);
         std::expected<Transaction, ExtraChain::Contracts::ContractFailure> submit_contract_deploy(
             std::string                   kind,
             std::span<const std::uint8_t> module,

--- a/headers/network/message_body.h
+++ b/headers/network/message_body.h
@@ -120,6 +120,7 @@ enum class MessageType {
     ConsensusBatchData          = 128,
     ConsensusSyncRequest        = 129,
     ConsensusSyncResponse       = 130,
+    ConsensusIntent             = 131,
 
     Unknown = 250
 };

--- a/headers/network/peer_meta.h
+++ b/headers/network/peer_meta.h
@@ -27,7 +27,7 @@
 inline constexpr std::string_view DAG_TX_BATCH_CAPABILITY     = "dag_tx_batch_v1";
 inline constexpr std::string_view TOKEN_MIGRATION_CAPABILITY  = "contract_token_migration_v1";
 inline constexpr std::string_view DAG_REPAIR_CAPABILITY       = "dag_repair_v1";
-inline constexpr std::string_view SHADOW_CONSENSUS_CAPABILITY = "shadow_consensus_v2";
+inline constexpr std::string_view SHADOW_CONSENSUS_CAPABILITY = "shadow_consensus_v3";
 
 #include "core/types.h"
 

--- a/scripts/check_shadow_model.sh
+++ b/scripts/check_shadow_model.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SPEC="$ROOT_DIR/spec/consensus/identity_bft_shadow.qnt"
+QUINT=(npx --yes @informalsystems/quint@0.32.0)
+
+"${QUINT[@]}" typecheck "$SPEC"
+
+for invariant in \
+    noConflictingFinality \
+    noHonestDoubleVote \
+    noDurableDoubleVote \
+    restartRestoresDurableVote \
+    lockDoesNotConflictWithDurableVote \
+    roundChangeRequiresQuorum \
+    voteRequiresAvailableData \
+    epochActivationIsTwoStep \
+    epochActivationRequiresFinality; do
+    "${QUINT[@]}" run "$SPEC" \
+        --main=shadow_consensus \
+        --invariant="$invariant" \
+        --max-steps=40 \
+        --max-samples=100000 \
+        --verbosity=0
+done

--- a/sources/chain/dag.cpp
+++ b/sources/chain/dag.cpp
@@ -20,10 +20,12 @@
 #include "chain/dag.h"
 #include "chain/dag_recovery.h"
 #include "consensus/consensus_service.h"
+#include "consensus/consensus_protocol.h"
 #include "contracts/contract_manager.h"
 #include "contracts/contract_transaction.h"
 
 #include <boost/asio/post.hpp>
+#include <charconv>
 #include <chrono>
 #include <cctype>
 #include <future>
@@ -724,6 +726,9 @@ std::expected<Transaction, TransactionError> Dag::send_transaction(const Transac
                  current_section_.to_string());
         return std::unexpected(TransactionError::NotReady);
     }
+    if (node->consensus() != nullptr && node->consensus()->requires_intent_v2()) {
+        return std::unexpected(TransactionError::IntentRequired);
+    }
 
     auto tx = this->prepare_transaction(transaction, signer);
     if (!tx.has_value()) {
@@ -747,6 +752,9 @@ std::expected<void, TransactionProveError> Dag::network_transaction_immediate(co
     }
     if (!state_projection_ready()) {
         return std::unexpected(TransactionProveError::StateUnavailable);
+    }
+    if (node->consensus() != nullptr && node->consensus()->requires_intent_v2()) {
+        return std::unexpected(TransactionProveError::IntentRequired);
     }
     if (status_ != DagStatus::Final) {
         /*
@@ -1996,18 +2004,13 @@ bool Dag::validate_repair_transaction(const Transaction &transaction, const std:
     if (sender.empty()) {
         return false;
     }
-    const auto signature_valid = sender.key().verify(transaction.hash(), transaction.signature());
-    if (!signature_valid.has_value() || !signature_valid.value()) {
+    if (!transaction.verify(sender)) {
         return false;
-    }
-
-    if (is_contract_transaction(transaction.type()) || is_token_migration_transaction(transaction.type())) {
-        return true;
     }
 
     const std::set<Transaction> empty;
     const auto                  frontier = transaction.section();
-    return prove_transaction(transaction, empty, &pending, &frontier) == TransactionProveError::NoError;
+    return prove_transaction(transaction, empty, &pending, &frontier, false) == TransactionProveError::NoError;
 }
 
 std::optional<std::map<SectionId, std::string>> Dag::validated_repair_candidate(
@@ -2069,7 +2072,7 @@ std::expected<ExtraChain::Consensus::SectionBatchData, ExtraChain::Consensus::Co
         }
         payload_bytes += bytes.size();
         for (const auto &transaction : section.value().transactions) {
-            batch.manifest.transaction_hashes.push_back(transaction.hash());
+            batch.manifest.transaction_hashes.push_back(consensus_transaction_hash(transaction));
         }
         const auto    section_text  = section_id.to_string();
         std::uint64_t section_value = 0;
@@ -2102,6 +2105,138 @@ std::expected<ExtraChain::Consensus::SectionBatchData, ExtraChain::Consensus::Co
     }
     batch.manifest.payload_bytes = payload_bytes;
     return batch;
+}
+
+std::expected<ExtraChain::Consensus::SectionBatchData, ExtraChain::Consensus::ConsensusError> Dag::
+    build_shadow_intent_batch(const SectionId                                          &first_section,
+                              const SectionId                                          &last_section,
+                              std::uint64_t                                             logical_time,
+                              const std::vector<ExtraChain::Consensus::IntentEnvelope> &intents,
+                              std::string                                               header_hash,
+                              std::optional<std::string>                                previous_section_bytes,
+                              std::string                                               previous_section_root) {
+    using namespace ExtraChain::Consensus;
+    constexpr std::size_t MaximumTransactionsPerSection = 256;
+    if (first_section < SectionId(0) || last_section < first_section
+        || last_section - first_section >= CONTROL_INTERVAL
+        || intents.size() > MaximumTransactionsPerSection
+                                * static_cast<std::size_t>(
+                                    (last_section - first_section + SectionId(1)).to_int().value_or(0))) {
+        return std::unexpected(ConsensusError::DataTooLarge);
+    }
+
+    std::set<std::string> previous_hashes;
+    if (first_section != SectionId(0)) {
+        std::optional<Section> previous;
+        if (previous_section_bytes.has_value()) {
+            auto decoded = Json::deserialize<Section>(previous_section_bytes.value());
+            if (decoded.has_value()) {
+                previous = std::move(decoded.value());
+            }
+        } else {
+            previous = read_section(first_section - SectionId(1));
+        }
+        if (!previous.has_value()) {
+            return std::unexpected(ConsensusError::DataUnavailable);
+        }
+        previous.value().id = first_section - SectionId(1);
+        previous_hashes     = previous.value().hashs();
+    }
+
+    std::vector<Section> sections;
+    const auto           section_count =
+        static_cast<std::size_t>((last_section - first_section + SectionId(1)).to_int().value_or(0));
+    sections.reserve(section_count);
+    for (std::size_t index = 0; index < section_count; ++index) {
+        const auto section_id = first_section + SectionId(index);
+        if (read_section(section_id).has_value()) {
+            return std::unexpected(ConsensusError::UnsafeProposal);
+        }
+        sections.push_back(Section { .id = section_id, .transactions = {}, .control = std::nullopt });
+    }
+
+    for (std::size_t index = 0; index < intents.size(); ++index) {
+        const auto section_index = index / MaximumTransactionsPerSection;
+        const auto materialized =
+            materialize_intent(intents[index],
+                               static_cast<std::uint64_t>(sections[section_index].id.to_int().value_or(0)),
+                               logical_time,
+                               previous_hashes);
+        if (!materialized.has_value()) {
+            return std::unexpected(materialized.error());
+        }
+        sections[section_index].transactions.insert(materialized.value());
+        if ((index + 1) % MaximumTransactionsPerSection == 0 && section_index + 1 < sections.size()) {
+            previous_hashes = sections[section_index].hashs();
+        }
+    }
+
+    SectionBatchData  batch { .header_hash = std::move(header_hash) };
+    std::uint64_t     payload_bytes = 0;
+    WireFormat::Scope canonical_scope(WireFormat::Mode::Canonical);
+    for (const auto &section : sections) {
+        const auto bytes = Json::serialize(section);
+        if (bytes.size() > std::numeric_limits<std::uint64_t>::max() - payload_bytes) {
+            return std::unexpected(ConsensusError::DataTooLarge);
+        }
+        payload_bytes += bytes.size();
+        for (const auto &transaction : section.transactions) {
+            batch.manifest.transaction_hashes.push_back(consensus_transaction_hash(transaction));
+        }
+        const auto section_value = section.id.to_int();
+        if (!section_value.has_value() || section_value.value() < 0) {
+            return std::unexpected(ConsensusError::InvalidRoot);
+        }
+        batch.sections.emplace_back(static_cast<std::uint64_t>(section_value.value()), bytes);
+    }
+
+    const auto first_value = first_section.to_int();
+    const auto last_value  = last_section.to_int();
+    if (!first_value.has_value() || !last_value.has_value() || first_value.value() < 0 || last_value.value() < 0) {
+        return std::unexpected(ConsensusError::InvalidRoot);
+    }
+    batch.manifest.first_section    = static_cast<std::uint64_t>(first_value.value());
+    batch.manifest.last_section     = static_cast<std::uint64_t>(last_value.value());
+    batch.manifest.transaction_root = calculate_transaction_root(batch.manifest.transaction_hashes);
+    batch.manifest.data_root        = calculate_data_root(batch.sections);
+    if (first_section != SectionId(0)) {
+        if (previous_section_root.empty()) {
+            const auto previous = read_control(first_section - SectionId(1));
+            if (!previous.has_value()) {
+                return std::unexpected(ConsensusError::DataUnavailable);
+            }
+            previous_section_root = previous.value().control;
+        }
+        batch.manifest.previous_section_root = std::move(previous_section_root);
+    }
+    batch.manifest.payload_bytes = payload_bytes;
+    return batch;
+}
+
+std::expected<std::string, ExtraChain::Consensus::ConsensusError> Dag::shadow_batch_section_root(
+    const ExtraChain::Consensus::SectionBatchData &batch) const {
+    using ExtraChain::Consensus::ConsensusError;
+    std::string       section_hashes;
+    WireFormat::Scope canonical_scope(WireFormat::Mode::Canonical);
+    for (const auto &[section_value, bytes] : batch.sections) {
+        auto section = Json::deserialize<Section>(bytes);
+        if (!section.has_value()) {
+            return std::unexpected(ConsensusError::InvalidRoot);
+        }
+        section.value().id = SectionId(section_value);
+        const auto input   = section.value().transactions.empty()
+                                 ? section.value().id.to_string()
+                                 : section.value().id.to_string() + section.value().calculate_hash();
+        section_hashes += Utils::calculate_hash(input);
+    }
+    auto root = Utils::calculate_hash(section_hashes);
+    if (batch.manifest.first_section != 0) {
+        if (batch.manifest.previous_section_root.empty()) {
+            return std::unexpected(ConsensusError::InvalidParent);
+        }
+        root = Utils::calculate_hash(batch.manifest.previous_section_root + root);
+    }
+    return root;
 }
 
 std::expected<void, ExtraChain::Consensus::ConsensusError> Dag::validate_shadow_batch(
@@ -2144,7 +2279,7 @@ std::expected<void, ExtraChain::Consensus::ConsensusError> Dag::validate_shadow_
             return std::unexpected(ConsensusError::InvalidRoot);
         }
         for (const auto &transaction : section.value().transactions) {
-            transaction_hashes.push_back(transaction.hash());
+            transaction_hashes.push_back(consensus_transaction_hash(transaction));
         }
         sections.insert_or_assign(section_id, bytes);
         ++expected_section;
@@ -2158,26 +2293,8 @@ std::expected<void, ExtraChain::Consensus::ConsensusError> Dag::validate_shadow_
         return std::unexpected(ConsensusError::InvalidRoot);
     }
 
-    std::string section_hashes;
-    for (const auto &[section_id, bytes] : sections) {
-        const auto section = Json::deserialize<Section>(bytes);
-        if (!section.has_value()) {
-            return std::unexpected(ConsensusError::InvalidRoot);
-        }
-        const auto input = section.value().transactions.empty()
-                               ? section_id.to_string()
-                               : section_id.to_string() + section.value().calculate_hash();
-        section_hashes += Utils::calculate_hash(input);
-    }
-    auto       expected_root = Utils::calculate_hash(section_hashes);
-    const auto first_section = SectionId(batch.manifest.first_section);
-    if (first_section != SectionId(0)) {
-        if (batch.manifest.previous_section_root.empty()) {
-            return std::unexpected(ConsensusError::InvalidParent);
-        }
-        expected_root = Utils::calculate_hash(batch.manifest.previous_section_root + expected_root);
-    }
-    if (expected_root != proposal.header.section_root) {
+    const auto expected_root = shadow_batch_section_root(batch);
+    if (!expected_root.has_value() || expected_root.value() != proposal.header.section_root) {
         return std::unexpected(ConsensusError::InvalidRoot);
     }
     return {};
@@ -2189,6 +2306,71 @@ std::expected<void, ExtraChain::Consensus::ConsensusError> Dag::install_shadow_b
     std::uint64_t                                  maximum_batch_bytes,
     const std::string                             &proof_hash) {
     using ExtraChain::Consensus::ConsensusError;
+    const auto contract_committed = [this](const Transaction &transaction) {
+        const auto record = node->contract_manager()->inspect(transaction.receiver().to_string());
+        return record.has_value() && std::ranges::any_of(record.value().versions, [&](const auto &version) {
+                   return std::ranges::any_of(version.revisions, [&](const auto &revision) {
+                       return revision.transaction_hash == transaction.hash();
+                   });
+               });
+    };
+    const auto commit_contract_intents =
+        [&](const std::map<SectionId, std::string> &sections) -> std::expected<void, ConsensusError> {
+        for (const auto &[_, bytes] : sections) {
+            const auto section = Json::deserialize<Section>(bytes);
+            if (!section.has_value()) {
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+            for (const auto &transaction : section.value().transactions) {
+                if (!transaction.consensus_intent().has_value() || !is_contract_transaction(transaction.type())
+                    || contract_committed(transaction)) {
+                    continue;
+                }
+                if (node->validate_contract_transaction(transaction) != TransactionProveError::NoError) {
+                    return std::unexpected(ConsensusError::InvalidIntent);
+                }
+                node->finalize_contract_change(transaction.hash(), true);
+                if (!contract_committed(transaction)) {
+                    return std::unexpected(ConsensusError::StorageFailure);
+                }
+            }
+        }
+        return {};
+    };
+
+    std::map<SectionId, std::string> canonical_sections;
+    for (const auto &[section, bytes] : batch.sections) {
+        canonical_sections.insert_or_assign(SectionId(section), bytes);
+    }
+    const auto last_control = read_control(SectionId(batch.manifest.last_section));
+    bool       already_installed =
+        last_control.has_value() && last_control.value().control == proposal.header.section_root;
+    if (already_installed) {
+        WireFormat::Scope canonical_scope(WireFormat::Mode::Canonical);
+        for (const auto &[section_id, expected] : canonical_sections) {
+            auto stored = read_section(section_id);
+            if (!stored.has_value()) {
+                already_installed = false;
+                break;
+            }
+            stored.value().control.reset();
+            if (Json::serialize(stored.value()) != expected) {
+                already_installed = false;
+                break;
+            }
+        }
+    }
+    if (already_installed) {
+        const auto contracts_committed = commit_contract_intents(canonical_sections);
+        if (!contracts_committed.has_value()) {
+            return std::unexpected(contracts_committed.error());
+        }
+        if (cache_.section() < SectionId(batch.manifest.last_section)) {
+            cache_.check_and_update_cache_thread(current_section_);
+        }
+        return {};
+    }
+
     const auto validated = validate_shadow_batch(proposal, batch, maximum_batch_bytes);
     if (!validated.has_value()) {
         return std::unexpected(validated.error());
@@ -2198,10 +2380,7 @@ std::expected<void, ExtraChain::Consensus::ConsensusError> Dag::install_shadow_b
     }
     std::unique_lock<std::recursive_mutex> save_lock(save_mutex_);
 
-    std::map<SectionId, std::string> sections;
-    for (const auto &[section, bytes] : batch.sections) {
-        sections.insert_or_assign(SectionId(section), bytes);
-    }
+    auto       sections           = std::move(canonical_sections);
     const auto first              = sections.begin()->first;
     const auto last               = sections.rbegin()->first;
     auto       recovery_incidents = recovery_journal_ == nullptr ? std::vector<DagRecoveryIncident> {}
@@ -2264,9 +2443,16 @@ std::expected<void, ExtraChain::Consensus::ConsensusError> Dag::install_shadow_b
         }
         chain_index_->flush();
     }
+    const auto contracts_committed = commit_contract_intents(sections);
+    if (!contracts_committed.has_value()) {
+        return std::unexpected(contracts_committed.error());
+    }
     if (!recovery_incidents.empty()
         && !replay_repaired_state(first, last, proposal.header.section_root, proof_hash)) {
         return std::unexpected(ConsensusError::StorageFailure);
+    }
+    if (recovery_incidents.empty() && first > cache_.section()) {
+        cache_.check_and_update_cache_thread(current_section_);
     }
     update_range(true);
     return {};
@@ -2390,13 +2576,15 @@ std::optional<std::pair<SectionId, SectionId>> Dag::save_transactions(const std:
 TransactionProveError Dag::prove_transaction(const Transaction           &tx,
                                              const std::set<Transaction> &transactions,
                                              const std::set<Transaction> *pending_transactions,
-                                             const SectionId             *validation_frontier) {
+                                             const SectionId             *validation_frontier,
+                                             bool                         stage_contract_change) {
     return prove_transaction_with_facts(tx,
                                         transactions,
                                         pending_transactions,
                                         nullptr,
                                         validation_frontier,
-                                        nullptr);
+                                        nullptr,
+                                        stage_contract_change);
 }
 
 TransactionProveError Dag::prove_transaction_with_facts(const Transaction           &tx,
@@ -2404,7 +2592,8 @@ TransactionProveError Dag::prove_transaction_with_facts(const Transaction       
                                                         const std::set<Transaction> *pending_transactions,
                                                         const std::unordered_set<std::string> *pending_hashes,
                                                         const SectionId                       *validation_frontier,
-                                                        const TransactionValidationFacts      *facts) {
+                                                        const TransactionValidationFacts      *facts,
+                                                        bool stage_contract_change) {
     // Check Genesis transactions
     if (tx.type() == TransactionType::Genesis) {
         if (tx.section() != SectionId(0)) {
@@ -2442,7 +2631,7 @@ TransactionProveError Dag::prove_transaction_with_facts(const Transaction       
 
     // Validate transaction amount
     if (tx.amount() == BigNumberFloat(0) && !is_contract_transaction(tx.type())
-        && !is_token_migration_transaction(tx.type())) {
+        && !is_token_migration_transaction(tx.type()) && !is_epoch_change_transaction(tx.type())) {
         return TransactionProveError::AmountZero;
     }
 
@@ -2514,9 +2703,20 @@ TransactionProveError Dag::prove_transaction_with_facts(const Transaction       
     const auto verify_stored_hash = [&]() {
         if (facts != nullptr && facts->signature_valid.has_value())
             return facts->signature_valid.value();
+        if (tx.consensus_intent().has_value()) {
+            return tx.verify(senderActor);
+        }
         const auto result = senderActor.key().verify(transaction_hash, tx.signature());
         return result.has_value() && *result;
     };
+
+    if (tx.type() == TransactionType::EpochChange) {
+        if (tx.amount() != 0 || !tx.token().is_zero() || !tx.meta().has_value() || tx.meta()->empty()
+            || tx.meta()->size() > 256 * 1024 || tx.signature().empty() || !tx.consensus_intent().has_value()) {
+            return TransactionProveError::InvalidContractPayload;
+        }
+        return verify_stored_hash() ? TransactionProveError::NoError : TransactionProveError::InvalidSignature;
+    }
 
     if (tx.type() == TransactionType::TokenMigration) {
         if (targetReceiver.is_zero() || targetSender == targetReceiver || tx.token().is_zero()
@@ -2550,7 +2750,7 @@ TransactionProveError Dag::prove_transaction_with_facts(const Transaction       
         if (!verify_stored_hash()) {
             return TransactionProveError::InvalidSignature;
         }
-        return node->validate_contract_transaction(tx);
+        return node->validate_contract_transaction(tx, stage_contract_change);
     }
 
     if (tx.type() == TransactionType::Regular && !tx.token().is_zero()) {
@@ -4830,8 +5030,7 @@ bool Dag::validate_received_pack(Pack::PackId id, const Pack::Reader &reader) co
             // The content hash was checked above. Verify the signature against
             // that exact stored hash, instead of recalculating and checking both
             // canonical and legacy preimages for every transaction.
-            const auto signature_valid = sender->second.key().verify(tx.hash(), tx.signature());
-            if (!signature_valid.has_value() || !signature_valid.value())
+            if (!tx.verify(sender->second))
                 return reject("invalid transaction signature");
         }
         sections.emplace(section_id, std::move(*section));

--- a/sources/chain/dag_admission.cpp
+++ b/sources/chain/dag_admission.cpp
@@ -350,8 +350,12 @@ private:
                 const auto sender = actors.find(transaction.sender());
                 result.sender_exists = sender != actors.end() && !sender->second.empty();
                 if (result.sender_exists.value() && !transaction.signature().empty()) {
-                    const auto signature = sender->second.key().verify(result.hash, transaction.signature());
-                    result.signature_valid = signature.has_value() && signature.value();
+                    if (transaction.consensus_intent().has_value()) {
+                        result.signature_valid = transaction.verify(sender->second);
+                    } else {
+                        const auto signature = sender->second.key().verify(result.hash, transaction.signature());
+                        result.signature_valid = signature.has_value() && signature.value();
+                    }
                 } else {
                     result.signature_valid = false;
                 }
@@ -425,7 +429,8 @@ private:
                                                              nullptr,
                                                              &pending_hashes,
                                                              &validation_frontier,
-                                                             &prevalidated[request_index]);
+                                                             &prevalidated[request_index],
+                                                             true);
             if (result != TransactionProveError::NoError) {
                 if (defer_future(request, prevalidated[request_index], result)) {
                     continue;

--- a/sources/chain/transaction.cpp
+++ b/sources/chain/transaction.cpp
@@ -19,6 +19,7 @@
 
 #include "chain/transaction.h"
 
+#include "consensus/consensus_protocol.h"
 #include "utils/exc_utils.h"
 
 namespace {
@@ -41,6 +42,9 @@ namespace {
         append_field(result, transaction.amount().to_string());
         append_field(result, std::to_string(transaction.timestamp()));
         append_field(result, transaction.meta().value_or(""));
+        if (transaction.consensus_intent().has_value()) {
+            append_field(result, transaction.consensus_intent().value());
+        }
         append_field(result, std::to_string(transaction.prev_hashs().size()));
         for (const auto &previous_hash : transaction.prev_hashs()) {
             append_field(result, previous_hash);
@@ -51,45 +55,48 @@ namespace {
 } // namespace
 
 Transaction::Transaction() {
-    this->sender_    = ActorId();
-    this->receiver_  = ActorId();
-    this->token_     = ActorId();
-    this->amount_    = BigNumberFloat(0);
-    this->timestamp_ = 0;
-    this->meta_      = std::nullopt;
-    this->section_   = BigNumber(0);
-    this->hash_      = "";
-    this->signature_ = Signature();
-    this->type_      = TransactionType::Regular;
+    this->sender_           = ActorId();
+    this->receiver_         = ActorId();
+    this->token_            = ActorId();
+    this->amount_           = BigNumberFloat(0);
+    this->timestamp_        = 0;
+    this->meta_             = std::nullopt;
+    this->consensus_intent_ = std::nullopt;
+    this->section_          = BigNumber(0);
+    this->hash_             = "";
+    this->signature_        = Signature();
+    this->type_             = TransactionType::Regular;
     update_hash();
 }
 
 Transaction::Transaction(const Transaction &other) {
-    this->sender_     = other.sender_;
-    this->receiver_   = other.receiver_;
-    this->amount_     = other.amount_;
-    this->timestamp_  = other.timestamp_;
-    this->meta_       = other.meta_;
-    this->token_      = other.token_;
-    this->section_    = other.section_;
-    this->hash_       = other.hash_;
-    this->signature_  = other.signature_;
-    this->type_       = other.type_;
-    this->prev_hashs_ = other.prev_hashs_;
+    this->sender_           = other.sender_;
+    this->receiver_         = other.receiver_;
+    this->amount_           = other.amount_;
+    this->timestamp_        = other.timestamp_;
+    this->meta_             = other.meta_;
+    this->consensus_intent_ = other.consensus_intent_;
+    this->token_            = other.token_;
+    this->section_          = other.section_;
+    this->hash_             = other.hash_;
+    this->signature_        = other.signature_;
+    this->type_             = other.type_;
+    this->prev_hashs_       = other.prev_hashs_;
 }
 
 Transaction::Transaction(Transaction &&other) noexcept {
-    sender_     = std::move(other.sender_);
-    receiver_   = std::move(other.receiver_);
-    amount_     = std::move(other.amount_);
-    timestamp_  = other.timestamp_;
-    meta_       = std::move(other.meta_);
-    token_      = std::move(other.token_);
-    section_    = std::move(other.section_);
-    hash_       = std::move(other.hash_);
-    signature_  = std::move(other.signature_);
-    type_       = std::move(other.type_);
-    prev_hashs_ = std::move(other.prev_hashs_);
+    sender_           = std::move(other.sender_);
+    receiver_         = std::move(other.receiver_);
+    amount_           = std::move(other.amount_);
+    timestamp_        = other.timestamp_;
+    meta_             = std::move(other.meta_);
+    consensus_intent_ = std::move(other.consensus_intent_);
+    token_            = std::move(other.token_);
+    section_          = std::move(other.section_);
+    hash_             = std::move(other.hash_);
+    signature_        = std::move(other.signature_);
+    type_             = std::move(other.type_);
+    prev_hashs_       = std::move(other.prev_hashs_);
 
     other.hash_ = "";
 }
@@ -114,6 +121,12 @@ void Transaction::set_meta(const std::string &value) {
     meta_ = value;
 }
 
+void Transaction::set_consensus_intent(std::string payload, Signature signature) {
+    consensus_intent_ = std::move(payload);
+    signature_        = std::move(signature);
+    update_hash();
+}
+
 void Transaction::set_prev_hashs(const std::set<std::string> &prev_hashs) {
     this->prev_hashs_ = prev_hashs;
 }
@@ -134,6 +147,9 @@ std::string Transaction::hash_preimage(bool hex) const {
 
     for (const auto &prev_hash : prev_hashs_) {
         hashData += prev_hash;
+    }
+    if (consensus_intent_.has_value()) {
+        hashData += consensus_intent_.value();
     }
     return hashData;
 }
@@ -196,6 +212,11 @@ bool Transaction::verify(const Actor<KeyPublic> &actor) const {
         return false;
     }
 
+    if (consensus_intent_.has_value()) {
+        return ExtraChain::Consensus::verify_materialized_intent(*this,
+                                                                 Utils::to_base64(actor.key().public_key()));
+    }
+
     // New signatures are computed over the decimal form. Transactions signed before
     // the hex → decimal migration still validate against the legacy hex form.
     auto verify_primary = actor.key().verify(calculate_hash(), signature_);
@@ -245,6 +266,10 @@ std::optional<std::string> Transaction::meta() const {
     return this->meta_;
 }
 
+const std::optional<std::string> &Transaction::consensus_intent() const noexcept {
+    return consensus_intent_;
+}
+
 Signature Transaction::signature() const {
     return this->signature_;
 }
@@ -278,6 +303,8 @@ bool Transaction::operator<(const Transaction &other) const {
         return token_ < other.token_;
     if (meta_ != other.meta_)
         return meta_ < other.meta_;
+    if (consensus_intent_ != other.consensus_intent_)
+        return consensus_intent_ < other.consensus_intent_;
     if (type_ != other.type_)
         return static_cast<int>(type_) < static_cast<int>(other.type_);
     if (prev_hashs_ != other.prev_hashs_) {
@@ -308,6 +335,8 @@ bool Transaction::operator==(const Transaction &transaction) const {
         return false;
     if (this->meta_ != transaction.meta())
         return false;
+    if (this->consensus_intent_ != transaction.consensus_intent())
+        return false;
     if (this->prev_hashs_ != transaction.prev_hashs())
         return false;
 
@@ -319,17 +348,18 @@ void Transaction::operator=(const Transaction &other) {
         return;
     }
 
-    this->sender_     = other.sender_;
-    this->receiver_   = other.receiver_;
-    this->amount_     = other.amount_;
-    this->timestamp_  = other.timestamp_;
-    this->meta_       = other.meta_;
-    this->token_      = other.token_;
-    this->section_    = other.section_;
-    this->hash_       = other.hash_;
-    this->signature_  = other.signature_;
-    this->type_       = other.type_;
-    this->prev_hashs_ = other.prev_hashs_;
+    this->sender_           = other.sender_;
+    this->receiver_         = other.receiver_;
+    this->amount_           = other.amount_;
+    this->timestamp_        = other.timestamp_;
+    this->meta_             = other.meta_;
+    this->consensus_intent_ = other.consensus_intent_;
+    this->token_            = other.token_;
+    this->section_          = other.section_;
+    this->hash_             = other.hash_;
+    this->signature_        = other.signature_;
+    this->type_             = other.type_;
+    this->prev_hashs_       = other.prev_hashs_;
 }
 
 Transaction &Transaction::operator=(Transaction &&other) noexcept {
@@ -337,17 +367,18 @@ Transaction &Transaction::operator=(Transaction &&other) noexcept {
         return *this;
     }
 
-    sender_     = std::move(other.sender_);
-    receiver_   = std::move(other.receiver_);
-    amount_     = std::move(other.amount_);
-    timestamp_  = std::move(other.timestamp_);
-    meta_       = std::move(other.meta_);
-    token_      = std::move(other.token_);
-    section_    = std::move(other.section_);
-    hash_       = std::move(other.hash_);
-    signature_  = std::move(other.signature_);
-    type_       = std::move(other.type_);
-    prev_hashs_ = std::move(other.prev_hashs_);
+    sender_           = std::move(other.sender_);
+    receiver_         = std::move(other.receiver_);
+    amount_           = std::move(other.amount_);
+    timestamp_        = std::move(other.timestamp_);
+    meta_             = std::move(other.meta_);
+    consensus_intent_ = std::move(other.consensus_intent_);
+    token_            = std::move(other.token_);
+    section_          = std::move(other.section_);
+    hash_             = std::move(other.hash_);
+    signature_        = std::move(other.signature_);
+    type_             = std::move(other.type_);
+    prev_hashs_       = std::move(other.prev_hashs_);
 
     other.hash_      = "";
     other.signature_ = {};

--- a/sources/consensus/consensus_engine.cpp
+++ b/sources/consensus/consensus_engine.cpp
@@ -11,6 +11,7 @@
 #include "consensus/consensus_engine.h"
 
 #include <algorithm>
+#include <chrono>
 #include <bit>
 #include <limits>
 #include <tuple>
@@ -21,8 +22,6 @@
 
 namespace ExtraChain::Consensus {
     namespace {
-        constexpr std::string_view GenesisDomain = "EXC_CONSENSUS_GENESIS_V1";
-        constexpr std::string_view StateDomain   = "EXC_CONSENSUS_STATE_V1";
 
         std::string vote_slot(const Vote& vote) {
             return fmt::format("{}:{}:{}:{}:{}",
@@ -72,11 +71,13 @@ namespace ExtraChain::Consensus {
     ConsensusEngine::ConsensusEngine(ValidatorSetView                 validators,
                                      std::optional<ValidatorIdentity> identity,
                                      std::unique_ptr<SafetyStore>     store,
-                                     ProposalValidator                proposal_validator)
+                                     ProposalValidator                proposal_validator,
+                                     std::optional<EpochBootstrapV1>  epoch_bootstrap)
         : validators_(std::move(validators))
         , identity_(std::move(identity))
         , store_(std::move(store))
-        , proposal_validator_(std::move(proposal_validator)) {
+        , proposal_validator_(std::move(proposal_validator))
+        , epoch_bootstrap_(std::move(epoch_bootstrap)) {
     }
 
     std::expected<void, ConsensusError> ConsensusEngine::initialize() {
@@ -93,6 +94,10 @@ namespace ExtraChain::Consensus {
                 || validator_id_for(identity_.value().key.public_key()) != record->validator_id) {
                 return std::unexpected(ConsensusError::NotValidator);
             }
+        }
+        if (epoch_bootstrap_.has_value()
+            && !verify_epoch_bootstrap(epoch_bootstrap_.value(), validators_.document())) {
+            return std::unexpected(ConsensusError::InvalidEpoch);
         }
         const auto opened = store_->open();
         if (!opened.has_value()) {
@@ -116,15 +121,16 @@ namespace ExtraChain::Consensus {
                      .protocol_version    = ProtocolVersion,
                      .network_id          = validators_.document().network_id,
                      .epoch               = validators_.document().epoch,
-                     .last_voted_height   = 0,
+                     .last_voted_height   = genesis.height,
                      .last_voted_round    = 0,
                      .last_voted_phase    = Phase::Genesis,
                      .last_voted_hash     = genesis.header_hash,
                      .highest_certificate = genesis,
                      .locked_certificate  = genesis,
-                     .finalized_height    = 0,
-                     .current_round       = 0,
-                     .validator_set_hash  = validators_.hash(),
+                     .finalized_height =
+                    epoch_bootstrap_.has_value() ? epoch_bootstrap_.value().previous_finalized_height : 0,
+                     .current_round      = 0,
+                     .validator_set_hash = validators_.hash(),
             };
             const auto persisted = store_->persist_state(safety_state_);
             if (!persisted.has_value()) {
@@ -210,7 +216,12 @@ namespace ExtraChain::Consensus {
             return std::unexpected(ConsensusError::InvalidRoot);
         }
         if (parent.phase == Phase::Genesis) {
-            if (batch.first_section != 0 && batch.previous_section_root.empty()) {
+            if (epoch_bootstrap_.has_value()
+                && (batch.first_section != epoch_bootstrap_.value().first_dag_section
+                    || batch.previous_section_root != epoch_bootstrap_.value().previous_section_root)) {
+                return std::unexpected(ConsensusError::InvalidParent);
+            }
+            if (!epoch_bootstrap_.has_value() && batch.first_section != 0 && batch.previous_section_root.empty()) {
                 return std::unexpected(ConsensusError::InvalidParent);
             }
         } else {
@@ -263,6 +274,7 @@ namespace ExtraChain::Consensus {
         }
         proposal.signature = signature.value();
         proposals_.insert_or_assign(hash_header(proposal.header), proposal);
+        proposals_created_.fetch_add(1, std::memory_order_relaxed);
         return proposal;
     }
 
@@ -301,6 +313,7 @@ namespace ExtraChain::Consensus {
             return std::unexpected(persisted.error());
         }
         safety_state_ = std::move(next_state);
+        timeout_votes_created_.fetch_add(1, std::memory_order_relaxed);
         return vote;
     }
 
@@ -356,6 +369,7 @@ namespace ExtraChain::Consensus {
         }
         safety_state_ = std::move(next_state);
         proposals_.insert_or_assign(vote.header_hash, proposal);
+        votes_created_.fetch_add(1, std::memory_order_relaxed);
         return vote;
     }
 
@@ -379,6 +393,7 @@ namespace ExtraChain::Consensus {
 
     std::expected<void, ConsensusError> ConsensusEngine::stage_batch(SectionBatchData batch) {
         std::lock_guard lock(mutex_);
+        const auto      started = std::chrono::steady_clock::now();
         if (!initialized_) {
             return std::unexpected(ConsensusError::NotReady);
         }
@@ -413,6 +428,12 @@ namespace ExtraChain::Consensus {
             }
         }
         batches_.insert_or_assign(batch.header_hash, std::move(batch));
+        batches_staged_.fetch_add(1, std::memory_order_relaxed);
+        stage_nanoseconds_.fetch_add(static_cast<std::uint64_t>(
+                                         std::chrono::duration_cast<std::chrono::nanoseconds>(
+                                             std::chrono::steady_clock::now() - started)
+                                             .count()),
+                                     std::memory_order_relaxed);
         return {};
     }
 
@@ -602,8 +623,10 @@ namespace ExtraChain::Consensus {
         certified_headers_.insert(certificate.header_hash);
         votes_.erase(certificate.header_hash);
         safety_state_ = std::move(next_state);
+        certificates_accepted_.fetch_add(1, std::memory_order_relaxed);
         if (finalized.has_value()) {
             finality_proofs_.insert_or_assign(finalized.value().height, finality_proof.value());
+            checkpoints_finalized_.fetch_add(1, std::memory_order_relaxed);
         }
         prune_memory(safety_state_.finalized_height);
         return finalized;
@@ -617,10 +640,12 @@ namespace ExtraChain::Consensus {
             return false;
         }
         if (certificate.phase == Phase::Genesis) {
-            return certificate.height == 0 && certificate.round == 0 && certificate.signatures.empty()
+            const auto expected = genesis_certificate();
+            return certificate.height == expected.height && certificate.round == 0
+                   && certificate.signatures.empty()
                    && certificate.signer_bitmap
                           == std::vector<std::uint8_t>((validators_.active().size() + 7) / 8, 0)
-                   && certificate.header_hash == genesis_certificate().header_hash;
+                   && certificate.header_hash == expected.header_hash;
         }
         if (certificate.phase != Phase::Prepare
             || certificate.signer_bitmap.size() != (validators_.active().size() + 7) / 8
@@ -754,20 +779,65 @@ namespace ExtraChain::Consensus {
         return stored.value();
     }
 
+    std::expected<std::optional<TransactionInclusionProofV1>, ConsensusError> ConsensusEngine::
+        transaction_inclusion_proof(std::string_view transaction_hash) const {
+        std::lock_guard lock(mutex_);
+        if (transaction_hash.empty()) {
+            return std::unexpected(ConsensusError::InvalidProof);
+        }
+        std::uint64_t cursor = 0;
+        while (true) {
+            const auto stored = store_->load_finality_proofs_after(cursor, MaximumShadowSyncProofs);
+            if (!stored.has_value()) {
+                return std::unexpected(stored.error());
+            }
+            for (const auto& finality_proof : stored.value()) {
+                if (!verify_finality_proof(finality_proof)) {
+                    return std::unexpected(ConsensusError::StorageFailure);
+                }
+                const auto& hashes = finality_proof.finalized_proposal.batch.transaction_hashes;
+                const auto  found  = std::ranges::find(hashes, transaction_hash);
+                if (found != hashes.end()) {
+                    const auto index = static_cast<std::size_t>(std::distance(hashes.begin(), found));
+                    const auto proof = make_merkle_proof(hashes, index);
+                    if (!proof.has_value()) {
+                        return std::unexpected(proof.error());
+                    }
+                    return TransactionInclusionProofV1 {
+                        .protocol_version = ProtocolVersion,
+                        .network_id       = validators_.document().network_id,
+                        .epoch            = validators_.document().epoch,
+                        .height           = finality_proof.finalized_proposal.header.height,
+                        .transaction_hash = std::string(transaction_hash),
+                        .merkle_proof     = proof.value(),
+                        .finality_proof   = finality_proof,
+                    };
+                }
+                cursor = finality_proof.finalized_proposal.header.height;
+            }
+            if (stored.value().size() < MaximumShadowSyncProofs) {
+                break;
+            }
+        }
+        return std::optional<TransactionInclusionProofV1> {};
+    }
+
+    bool ConsensusEngine::verify_transaction_inclusion_proof(const TransactionInclusionProofV1& proof) const {
+        std::lock_guard lock(mutex_);
+        const auto&     proposal = proof.finality_proof.finalized_proposal;
+        if (proof.protocol_version != ProtocolVersion || proof.network_id != validators_.document().network_id
+            || proof.epoch != validators_.document().epoch || proof.height != proposal.header.height
+            || proof.transaction_hash.empty()) {
+            return false;
+        }
+        return verify_finality_proof(proof.finality_proof)
+               && proposal.header.transaction_root == proposal.batch.transaction_root
+               && verify_merkle_proof(proof.transaction_hash, proof.merkle_proof, proposal.batch.transaction_root);
+    }
+
     QuorumCertificate ConsensusEngine::genesis_certificate() const {
-        const auto payload =
-            std::string(GenesisDomain) + validators_.document().network_id.to_string() + validators_.hash();
-        return QuorumCertificate {
-            .protocol_version = ProtocolVersion,
-            .network_id       = validators_.document().network_id,
-            .epoch            = validators_.document().epoch,
-            .height           = 0,
-            .round            = 0,
-            .phase            = Phase::Genesis,
-            .header_hash      = Utils::calculate_hash(payload, Utils::HashAlgorithm::Blake3),
-            .signer_bitmap    = std::vector<std::uint8_t>((validators_.active().size() + 7) / 8, 0),
-            .signatures       = {},
-        };
+        return epoch_bootstrap_.has_value() ? make_epoch_genesis_certificate(validators_, epoch_bootstrap_.value())
+                                            : make_genesis_certificate(validators_);
     }
 
     const ValidatorSetView& ConsensusEngine::validators() const noexcept {
@@ -780,6 +850,10 @@ namespace ExtraChain::Consensus {
 
     const std::optional<ValidatorIdentity>& ConsensusEngine::identity() const noexcept {
         return identity_;
+    }
+
+    const std::optional<EpochBootstrapV1>& ConsensusEngine::epoch_bootstrap() const noexcept {
+        return epoch_bootstrap_;
     }
 
     bool ConsensusEngine::is_local_leader(std::uint64_t height, std::uint64_t round) const {
@@ -801,6 +875,18 @@ namespace ExtraChain::Consensus {
         }
         const auto stored = store_->load_batch(header_hash);
         return stored.has_value() ? stored.value() : std::nullopt;
+    }
+
+    ConsensusMetricsSnapshot ConsensusEngine::metrics() const noexcept {
+        return ConsensusMetricsSnapshot {
+            .proposals_created = proposals_created_.load(std::memory_order_relaxed),
+            .batches_staged    = batches_staged_.load(std::memory_order_relaxed),
+            .votes_created     = votes_created_.load(std::memory_order_relaxed),
+            .timeout_votes     = timeout_votes_created_.load(std::memory_order_relaxed),
+            .certificates      = certificates_accepted_.load(std::memory_order_relaxed),
+            .finalized         = checkpoints_finalized_.load(std::memory_order_relaxed),
+            .stage_nanoseconds = stage_nanoseconds_.load(std::memory_order_relaxed),
+        };
     }
 
     bool ConsensusEngine::verify_proposal(const Proposal& proposal) const {
@@ -835,7 +921,13 @@ namespace ExtraChain::Consensus {
             return false;
         }
         if (proposal.parent_certificate.phase == Phase::Genesis) {
-            if (proposal.batch.first_section == 0 && !proposal.batch.previous_section_root.empty()) {
+            if (epoch_bootstrap_.has_value()
+                && (proposal.batch.first_section != epoch_bootstrap_.value().first_dag_section
+                    || proposal.batch.previous_section_root != epoch_bootstrap_.value().previous_section_root)) {
+                return false;
+            }
+            if (!epoch_bootstrap_.has_value() && proposal.batch.first_section == 0
+                && !proposal.batch.previous_section_root.empty()) {
                 return false;
             }
         } else {
@@ -959,10 +1051,7 @@ namespace ExtraChain::Consensus {
     std::string ConsensusEngine::state_commitment(const QuorumCertificate& parent,
                                                   std::string_view         section_root,
                                                   std::string_view         batch_root) const {
-        return Utils::calculate_hash(std::string(StateDomain) + hash_certificate(parent)
-                                         + std::string(section_root) + std::string(batch_root)
-                                         + validators_.hash(),
-                                     Utils::HashAlgorithm::Blake3);
+        return calculate_consensus_state_commitment(parent, section_root, batch_root, validators_.hash());
     }
 
     void ConsensusEngine::prune_memory(std::uint64_t finalized_height) {

--- a/sources/consensus/consensus_protocol.cpp
+++ b/sources/consensus/consensus_protocol.cpp
@@ -1,0 +1,731 @@
+/*
+ * ExtraChain Core
+ * Copyright (C) 2025 ExtraChain Foundation <official@extrachain.io>
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, Inc., either version 3 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "consensus/consensus_protocol.h"
+
+#include <algorithm>
+#include <limits>
+#include <queue>
+#include <set>
+#include <tuple>
+
+#include "chain/transaction.h"
+#include "core/byte_array.h"
+#include "utils/exc_utils.h"
+#include "utils/exc_utils_base64.h"
+#include "utils/serialization.h"
+
+namespace ExtraChain::Consensus {
+    namespace {
+        constexpr std::string_view IntentMetadataDomain = "EXC_INTENT_METADATA_V2";
+        constexpr std::string_view IntentDomain         = "EXC_TRANSACTION_INTENT_V2";
+        constexpr std::string_view MerkleLeafDomain     = "EXC_SHADOW_TRANSACTION_LEAF_V2";
+        constexpr std::string_view MerkleNodeDomain     = "EXC_SHADOW_TRANSACTION_NODE_V2";
+        constexpr std::string_view PolicyDomain         = "EXC_GOVERNANCE_POLICY_V1";
+        constexpr std::string_view AuthorizationDomain  = "EXC_GOVERNANCE_AUTHORIZATION_V1";
+        constexpr std::string_view EpochChangeDomain    = "EXC_EPOCH_CHANGE_V1";
+        constexpr std::string_view EpochBootstrapDomain = "EXC_EPOCH_BOOTSTRAP_V1";
+        constexpr std::string_view RecoveryDomain       = "EXC_EMERGENCY_RECOVERY_V1";
+        constexpr std::string_view ActivationDomain     = "EXC_SHADOW_ACTIVATION_V1";
+        constexpr std::string_view StateDomain          = "EXC_STATE_COMMITMENT_V2";
+        constexpr std::uint64_t    MaximumStoredHeight =
+            static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+
+        template <typename T>
+        std::string domain_hash(std::string_view domain, const T& value) {
+            return Utils::calculate_hash(std::string(domain) + MessagePack::serialize(value),
+                                         Utils::HashAlgorithm::Blake3);
+        }
+
+        std::optional<ActorId> actor_id_for(std::string_view encoded_public_key) {
+            const auto decoded = ByteArray::fromBase64(encoded_public_key);
+            if (!decoded.has_value() || decoded.value().size() != crypto_sign_PUBLICKEYBYTES) {
+                return std::nullopt;
+            }
+            const auto hash = Utils::calculate_hash(decoded.value().toString(), Utils::HashAlgorithm::Blake3);
+            const auto id   = ActorId::create(hash.substr(0, ActorId::SIZE));
+            return id.has_value() ? std::optional<ActorId>(id.value()) : std::nullopt;
+        }
+
+        std::string merkle_leaf(std::string_view value) {
+            return Utils::calculate_hash(std::string(MerkleLeafDomain) + std::string(value),
+                                         Utils::HashAlgorithm::Blake3);
+        }
+
+        std::string merkle_parent(std::string_view left, std::string_view right) {
+            return Utils::calculate_hash(std::string(MerkleNodeDomain) + std::string(left) + std::string(right),
+                                         Utils::HashAlgorithm::Blake3);
+        }
+
+        std::vector<std::string> next_merkle_level(const std::vector<std::string>& level) {
+            std::vector<std::string> next;
+            next.reserve((level.size() + 1) / 2);
+            for (std::size_t index = 0; index < level.size(); index += 2) {
+                const auto& right = index + 1 < level.size() ? level[index + 1] : level[index];
+                next.push_back(merkle_parent(level[index], right));
+            }
+            return next;
+        }
+
+        bool valid_amount(std::string_view amount) {
+            if (amount.empty() || amount.size() > 128 || amount.front() == '-' || amount.front() == '+'
+                || amount.front() == '.' || amount.back() == '.') {
+                return false;
+            }
+            const auto decimal = amount.find('.');
+            if (decimal != std::string_view::npos && amount.find('.', decimal + 1) != std::string_view::npos) {
+                return false;
+            }
+            const auto integer_digits = decimal == std::string_view::npos ? amount.size() : decimal;
+            if (integer_digits > 1 && amount.front() == '0') {
+                return false;
+            }
+            return std::ranges::all_of(amount, [](char value) {
+                return value == '.' || (value >= '0' && value <= '9');
+            });
+        }
+
+        bool valid_operation(IntentOperation operation) {
+            switch (operation) {
+            case IntentOperation::Transfer:
+            case IntentOperation::ContractDeploy:
+            case IntentOperation::ContractCall:
+            case IntentOperation::ContractUpgrade:
+            case IntentOperation::TokenMigration:
+            case IntentOperation::EpochChange:
+                return true;
+            }
+            return false;
+        }
+
+        bool positive_amount(std::string_view amount) {
+            return valid_amount(amount) && std::ranges::any_of(amount, [](char value) {
+                       return value >= '1' && value <= '9';
+                   });
+        }
+
+        std::optional<TransactionType> transaction_type(IntentOperation operation) {
+            switch (operation) {
+            case IntentOperation::Transfer:
+                return TransactionType::Regular;
+            case IntentOperation::ContractDeploy:
+                return TransactionType::ContractDeploy;
+            case IntentOperation::ContractCall:
+                return TransactionType::ContractCall;
+            case IntentOperation::ContractUpgrade:
+                return TransactionType::ContractUpgrade;
+            case IntentOperation::TokenMigration:
+                return TransactionType::TokenMigration;
+            case IntentOperation::EpochChange:
+                return TransactionType::EpochChange;
+            }
+            return std::nullopt;
+        }
+
+        std::string authorization_payload(const MultisigPolicy&          policy,
+                                          const GovernanceAuthorization& authorization) {
+            return std::string(AuthorizationDomain)
+                   + MessagePack::serialize(std::tuple { policy.policy_hash,
+                                                         authorization.protocol_version,
+                                                         authorization.network_id,
+                                                         authorization.sequence,
+                                                         authorization.action_hash });
+        }
+
+        std::string unsigned_epoch_change_hash(const EpochChangeV1& change) {
+            return domain_hash(EpochChangeDomain,
+                               std::tuple { change.protocol_version,
+                                            change.network_id,
+                                            change.current_epoch,
+                                            change.activation_epoch,
+                                            change.activation_height,
+                                            change.current_validator_set_hash,
+                                            change.next_validator_set_hash,
+                                            change.registry_document_hash,
+                                            change.operators });
+        }
+
+        std::string unsigned_recovery_hash(const RecoveryDocumentV1& recovery) {
+            return domain_hash(RecoveryDomain,
+                               std::tuple { recovery.protocol_version,
+                                            recovery.network_id,
+                                            recovery.recovery_sequence,
+                                            recovery.finalized_height,
+                                            recovery.finalized_checkpoint_hash,
+                                            recovery.next_validator_set_hash,
+                                            recovery.registry_document_hash });
+        }
+
+        std::string unsigned_activation_hash(const ActivationManifestV1& activation) {
+            return domain_hash(ActivationDomain,
+                               std::tuple { activation.protocol_version,
+                                            activation.network_id,
+                                            activation.activation_height,
+                                            activation.activation_dag_section,
+                                            activation.validator_set_hash,
+                                            activation.require_intent_v2 });
+        }
+    } // namespace
+
+    std::string intent_metadata_hash(std::string_view metadata) {
+        return Utils::calculate_hash(std::string(IntentMetadataDomain) + std::string(metadata),
+                                     Utils::HashAlgorithm::Blake3);
+    }
+
+    std::string intent_signing_payload(const TransactionIntentV2& intent) {
+        return std::string(IntentDomain)
+               + MessagePack::serialize(std::tuple { intent.protocol_version,
+                                                     intent.network_id,
+                                                     intent.sender,
+                                                     intent.receiver,
+                                                     intent.token,
+                                                     intent.amount,
+                                                     intent.operation,
+                                                     intent.metadata_hash,
+                                                     intent.account_nonce,
+                                                     intent.valid_after_height,
+                                                     intent.expires_after_height });
+    }
+
+    std::string hash_intent(const TransactionIntentV2& intent) {
+        return Utils::calculate_hash(intent_signing_payload(intent), Utils::HashAlgorithm::Blake3);
+    }
+
+    std::expected<TransactionIntentV2, ConsensusError> make_intent(TransactionIntentV2      intent,
+                                                                   std::string_view         metadata,
+                                                                   const Actor<KeyPrivate>& sender) {
+        if (intent.protocol_version != ProtocolVersion || intent.network_id.is_zero() || sender.empty()
+            || intent.sender != sender.id() || intent.receiver.is_zero() || !valid_amount(intent.amount)
+            || !valid_operation(intent.operation)
+            || (intent.operation == IntentOperation::Transfer && !positive_amount(intent.amount))
+            || intent.account_nonce == 0 || intent.account_nonce > MaximumStoredHeight
+            || intent.valid_after_height > MaximumStoredHeight || intent.expires_after_height > MaximumStoredHeight
+            || intent.expires_after_height <= intent.valid_after_height) {
+            return std::unexpected(ConsensusError::InvalidIntent);
+        }
+        intent.metadata_hash = intent_metadata_hash(metadata);
+        const auto signature = sign_payload(sender.key(), intent_signing_payload(intent));
+        if (!signature.has_value()) {
+            return std::unexpected(signature.error());
+        }
+        intent.signature = signature.value();
+        return intent;
+    }
+
+    bool verify_intent(const IntentEnvelope& envelope, std::string_view sender_public_key) {
+        const auto& intent   = envelope.intent;
+        const auto  actor_id = actor_id_for(sender_public_key);
+        return intent.protocol_version == ProtocolVersion && !intent.network_id.is_zero() && actor_id.has_value()
+               && actor_id.value() == intent.sender && !intent.receiver.is_zero() && valid_amount(intent.amount)
+               && valid_operation(intent.operation)
+               && (intent.operation != IntentOperation::Transfer || positive_amount(intent.amount))
+               && intent.account_nonce != 0 && intent.expires_after_height > intent.valid_after_height
+               && intent.account_nonce <= MaximumStoredHeight && intent.valid_after_height <= MaximumStoredHeight
+               && intent.expires_after_height <= MaximumStoredHeight
+               && intent.metadata_hash == intent_metadata_hash(envelope.metadata)
+               && verify_payload(std::string(sender_public_key), intent_signing_payload(intent), intent.signature);
+    }
+
+    std::expected<Transaction, ConsensusError> materialize_intent(const IntentEnvelope&        envelope,
+                                                                  std::uint64_t                section,
+                                                                  std::uint64_t                logical_time,
+                                                                  const std::set<std::string>& previous_hashes) {
+        const auto type      = transaction_type(envelope.intent.operation);
+        const auto amount    = BigNumberFloat::create(envelope.intent.amount);
+        const auto signature = ByteArray::fromBase64(envelope.intent.signature);
+        if (!type.has_value() || !amount.has_value() || !signature.has_value()
+            || signature.value().size() != crypto_sign_BYTES) {
+            return std::unexpected(ConsensusError::InvalidIntent);
+        }
+
+        Transaction transaction;
+        transaction.set_type(type.value());
+        transaction.set_sender(envelope.intent.sender);
+        transaction.set_receiver(envelope.intent.receiver);
+        transaction.set_token(envelope.intent.token);
+        transaction.set_amount(amount.value());
+        transaction.set_section(SectionId(section));
+        transaction.set_timestamp(logical_time);
+        transaction.set_meta(envelope.metadata);
+        transaction.set_prev_hashs(previous_hashes);
+        transaction.set_consensus_intent(Utils::to_base64(MessagePack::serialize(envelope)),
+                                         signature.value().toArray<crypto_sign_BYTES>());
+        transaction.update_hash();
+        return transaction;
+    }
+
+    std::expected<IntentEnvelope, ConsensusError> intent_from_transaction(const Transaction& transaction) {
+        if (!transaction.consensus_intent().has_value()) {
+            return std::unexpected(ConsensusError::InvalidIntent);
+        }
+        const auto bytes = Utils::from_base64(transaction.consensus_intent().value());
+        if (!bytes.has_value()) {
+            return std::unexpected(ConsensusError::InvalidIntent);
+        }
+        const auto envelope = MessagePack::deserialize<IntentEnvelope>(bytes.value());
+        if (!envelope.has_value()) {
+            return std::unexpected(ConsensusError::InvalidIntent);
+        }
+        return envelope.value();
+    }
+
+    bool verify_materialized_intent(const Transaction& transaction, std::string_view sender_public_key) {
+        const auto envelope = intent_from_transaction(transaction);
+        if (!envelope.has_value() || !verify_intent(envelope.value(), sender_public_key)) {
+            return false;
+        }
+        const auto type      = transaction_type(envelope.value().intent.operation);
+        const auto amount    = BigNumberFloat::create(envelope.value().intent.amount);
+        const auto signature = ByteArray::fromBase64(envelope.value().intent.signature);
+        return type.has_value() && amount.has_value() && signature.has_value()
+               && signature.value().size() == crypto_sign_BYTES && transaction.type() == type.value()
+               && transaction.sender() == envelope.value().intent.sender
+               && transaction.receiver() == envelope.value().intent.receiver
+               && transaction.token() == envelope.value().intent.token && transaction.amount() == amount.value()
+               && transaction.meta().value_or("") == envelope.value().metadata
+               && transaction.signature() == signature.value().toArray<crypto_sign_BYTES>();
+    }
+
+    std::string consensus_transaction_hash(const Transaction& transaction) {
+        const auto envelope = intent_from_transaction(transaction);
+        if (!envelope.has_value()) {
+            return transaction.hash();
+        }
+        if (envelope.value().intent.operation == IntentOperation::EpochChange) {
+            const auto bytes = Utils::from_base64(envelope.value().metadata);
+            if (bytes.has_value()) {
+                const auto request = MessagePack::deserialize<EpochChangeRequestV1>(bytes.value());
+                if (request.has_value() && request.value().protocol_version == ProtocolVersion) {
+                    return epoch_change_action_hash(request.value().change);
+                }
+            }
+        }
+        return hash_intent(envelope.value().intent);
+    }
+
+    IntentPool::IntentPool(IntentPoolLimits limits)
+        : limits_(limits) {
+    }
+
+    std::expected<std::string, ConsensusError> IntentPool::submit(const IntentEnvelope& envelope,
+                                                                  std::string_view      sender_public_key,
+                                                                  std::uint64_t         committed_nonce,
+                                                                  std::uint64_t         current_height) {
+        if (!verify_intent(envelope, sender_public_key)) {
+            return std::unexpected(ConsensusError::InvalidIntent);
+        }
+        const auto& intent = envelope.intent;
+        if (current_height > intent.expires_after_height) {
+            return std::unexpected(ConsensusError::IntentExpired);
+        }
+        if (intent.account_nonce <= committed_nonce
+            || intent.account_nonce - committed_nonce > limits_.maximum_nonce_gap) {
+            return std::unexpected(ConsensusError::InvalidNonce);
+        }
+        if (envelope.metadata.size() > limits_.maximum_metadata_bytes) {
+            return std::unexpected(ConsensusError::DataTooLarge);
+        }
+        const auto hash = hash_intent(intent);
+        if (entries_.contains(hash)) {
+            return std::unexpected(ConsensusError::DuplicateIntent);
+        }
+        const auto bytes        = MessagePack::serialize(envelope).size();
+        const auto sender_count = sender_counts_.contains(intent.sender) ? sender_counts_.at(intent.sender) : 0;
+        if (entries_.size() >= limits_.maximum_intents || sender_count >= limits_.maximum_sender_intents
+            || bytes > limits_.maximum_bytes - std::min(bytes_, limits_.maximum_bytes)) {
+            return std::unexpected(ConsensusError::PoolFull);
+        }
+        entries_.emplace(hash, Entry { .envelope = envelope, .bytes = bytes });
+        ++sender_counts_[intent.sender];
+        bytes_ += bytes;
+        return hash;
+    }
+
+    std::vector<IntentEnvelope> IntentPool::ready(const std::map<ActorId, std::uint64_t>& committed_nonces,
+                                                  std::uint64_t                           current_height,
+                                                  std::size_t                             maximum_count,
+                                                  std::size_t                             maximum_bytes) const {
+        using SenderQueue = std::map<std::uint64_t, const Entry*>;
+        std::map<ActorId, SenderQueue> by_sender;
+        for (const auto& [_, entry] : entries_) {
+            const auto& intent = entry.envelope.intent;
+            if (current_height < intent.valid_after_height || current_height > intent.expires_after_height) {
+                continue;
+            }
+            by_sender[intent.sender].emplace(intent.account_nonce, &entry);
+        }
+
+        struct Candidate {
+            std::string  hash;
+            const Entry* entry = nullptr;
+        };
+        const auto later = [](const Candidate& left, const Candidate& right) {
+            return left.hash > right.hash;
+        };
+        std::priority_queue<Candidate, std::vector<Candidate>, decltype(later)> candidates(later);
+        for (const auto& [sender, queue] : by_sender) {
+            const auto committed = committed_nonces.contains(sender) ? committed_nonces.at(sender) : 0;
+            const auto next      = committed + 1;
+            const auto found     = queue.find(next);
+            if (found != queue.end()) {
+                candidates.push(
+                    Candidate { .hash = hash_intent(found->second->envelope.intent), .entry = found->second });
+            }
+        }
+
+        std::vector<IntentEnvelope> result;
+        std::size_t                 selected_bytes           = 0;
+        bool                        contract_change_selected = false;
+        bool                        epoch_change_selected    = false;
+        while (!candidates.empty() && result.size() < maximum_count) {
+            auto candidate = candidates.top();
+            candidates.pop();
+            if (candidate.entry->bytes > maximum_bytes - std::min(selected_bytes, maximum_bytes)) {
+                continue;
+            }
+            const auto& intent           = candidate.entry->envelope.intent;
+            const bool  changes_contract = intent.operation == IntentOperation::ContractDeploy
+                                          || intent.operation == IntentOperation::ContractCall
+                                          || intent.operation == IntentOperation::ContractUpgrade
+                                          || intent.operation == IntentOperation::TokenMigration;
+            if ((changes_contract && contract_change_selected)
+                || (intent.operation == IntentOperation::EpochChange && epoch_change_selected)) {
+                continue;
+            }
+            result.push_back(candidate.entry->envelope);
+            selected_bytes += candidate.entry->bytes;
+            if (changes_contract) {
+                contract_change_selected = true;
+            }
+            epoch_change_selected = epoch_change_selected || intent.operation == IntentOperation::EpochChange;
+        }
+        return result;
+    }
+
+    std::vector<std::string> IntentPool::expire(std::uint64_t current_height) {
+        std::vector<std::string> expired;
+        for (auto iterator = entries_.begin(); iterator != entries_.end();) {
+            if (iterator->second.envelope.intent.expires_after_height >= current_height) {
+                ++iterator;
+                continue;
+            }
+            expired.push_back(iterator->first);
+            bytes_ -= iterator->second.bytes;
+            const auto sender = iterator->second.envelope.intent.sender;
+            if (--sender_counts_[sender] == 0) {
+                sender_counts_.erase(sender);
+            }
+            iterator = entries_.erase(iterator);
+        }
+        return expired;
+    }
+
+    void IntentPool::erase(const std::vector<std::string>& intent_hashes) {
+        for (const auto& hash : intent_hashes) {
+            const auto found = entries_.find(hash);
+            if (found == entries_.end()) {
+                continue;
+            }
+            bytes_ -= found->second.bytes;
+            const auto sender = found->second.envelope.intent.sender;
+            if (--sender_counts_[sender] == 0) {
+                sender_counts_.erase(sender);
+            }
+            entries_.erase(found);
+        }
+    }
+
+    std::size_t IntentPool::size() const noexcept {
+        return entries_.size();
+    }
+
+    std::size_t IntentPool::bytes() const noexcept {
+        return bytes_;
+    }
+
+    std::string merkle_root(const std::vector<std::string>& values) {
+        return calculate_transaction_root(values);
+    }
+
+    std::expected<MerkleProof, ConsensusError> make_merkle_proof(const std::vector<std::string>& values,
+                                                                 std::size_t                     index) {
+        if (values.empty() || index >= values.size()) {
+            return std::unexpected(ConsensusError::InvalidProof);
+        }
+        MerkleProof proof {
+            .leaf_index = index,
+            .leaf_count = values.size(),
+            .leaf_hash  = merkle_leaf(values[index]),
+        };
+        std::vector<std::string> level;
+        level.reserve(values.size());
+        std::ranges::transform(values, std::back_inserter(level), merkle_leaf);
+        auto position = index;
+        while (level.size() > 1) {
+            auto sibling = position % 2 == 0 ? position + 1 : position - 1;
+            if (sibling >= level.size()) {
+                sibling = position;
+            }
+            proof.siblings.push_back(level[sibling]);
+            level = next_merkle_level(level);
+            position /= 2;
+        }
+        return proof;
+    }
+
+    bool verify_merkle_proof(std::string_view value, const MerkleProof& proof, std::string_view expected_root) {
+        if (proof.leaf_count == 0 || proof.leaf_index >= proof.leaf_count
+            || proof.leaf_hash != merkle_leaf(value)) {
+            return false;
+        }
+        auto        hash          = proof.leaf_hash;
+        auto        position      = proof.leaf_index;
+        auto        width         = proof.leaf_count;
+        std::size_t sibling_index = 0;
+        while (width > 1) {
+            if (sibling_index >= proof.siblings.size()) {
+                return false;
+            }
+            hash = position % 2 == 0 ? merkle_parent(hash, proof.siblings[sibling_index])
+                                     : merkle_parent(proof.siblings[sibling_index], hash);
+            position /= 2;
+            width = (width + 1) / 2;
+            ++sibling_index;
+        }
+        return sibling_index == proof.siblings.size() && hash == expected_root;
+    }
+
+    std::expected<MultisigPolicy, ConsensusError> make_multisig_policy(const ActorId&           network_id,
+                                                                       std::uint16_t            threshold,
+                                                                       std::vector<std::string> public_keys) {
+        std::ranges::sort(public_keys);
+        if (network_id.is_zero() || public_keys.empty() || threshold == 0 || threshold > public_keys.size()
+            || std::ranges::adjacent_find(public_keys) != public_keys.end()
+            || std::ranges::any_of(public_keys, [](const auto& key) {
+                   const auto decoded = ByteArray::fromBase64(key);
+                   return !decoded.has_value() || decoded.value().size() != crypto_sign_PUBLICKEYBYTES;
+               })) {
+            return std::unexpected(ConsensusError::InvalidGovernance);
+        }
+        MultisigPolicy policy {
+            .protocol_version = ProtocolVersion,
+            .network_id       = network_id,
+            .threshold        = threshold,
+            .public_keys      = std::move(public_keys),
+        };
+        policy.policy_hash = domain_hash(PolicyDomain,
+                                         std::tuple { policy.protocol_version,
+                                                      policy.network_id,
+                                                      policy.threshold,
+                                                      policy.public_keys });
+        return policy;
+    }
+
+    bool verify_multisig_policy(const MultisigPolicy& policy) {
+        if (policy.protocol_version != ProtocolVersion || policy.network_id.is_zero() || policy.public_keys.empty()
+            || policy.threshold == 0 || policy.threshold > policy.public_keys.size()
+            || !std::ranges::is_sorted(policy.public_keys)
+            || std::ranges::adjacent_find(policy.public_keys) != policy.public_keys.end()
+            || std::ranges::any_of(policy.public_keys, [](const auto& key) {
+                   const auto decoded = ByteArray::fromBase64(key);
+                   return !decoded.has_value() || decoded.value().size() != crypto_sign_PUBLICKEYBYTES;
+               })) {
+            return false;
+        }
+        return policy.policy_hash
+               == domain_hash(PolicyDomain,
+                              std::tuple { policy.protocol_version,
+                                           policy.network_id,
+                                           policy.threshold,
+                                           policy.public_keys });
+    }
+
+    std::expected<GovernanceAuthorization, ConsensusError> authorize_action(
+        const MultisigPolicy&          policy,
+        std::uint64_t                  sequence,
+        std::string                    action_hash,
+        const std::vector<KeyPrivate>& signers) {
+        if (sequence == 0 || action_hash.empty() || !verify_multisig_policy(policy)) {
+            return std::unexpected(ConsensusError::InvalidGovernance);
+        }
+        GovernanceAuthorization authorization {
+            .protocol_version = ProtocolVersion,
+            .network_id       = policy.network_id,
+            .sequence         = sequence,
+            .action_hash      = std::move(action_hash),
+        };
+        const auto              payload = authorization_payload(policy, authorization);
+        std::set<std::uint16_t> used;
+        for (const auto& signer : signers) {
+            const auto encoded = Utils::to_base64(signer.public_key());
+            const auto found   = std::ranges::lower_bound(policy.public_keys, encoded);
+            if (found == policy.public_keys.end() || *found != encoded) {
+                continue;
+            }
+            const auto index = static_cast<std::uint16_t>(std::distance(policy.public_keys.begin(), found));
+            if (!used.insert(index).second) {
+                continue;
+            }
+            const auto signature = sign_payload(signer, payload);
+            if (!signature.has_value()) {
+                return std::unexpected(signature.error());
+            }
+            authorization.signatures.push_back(
+                IndexedSignature { .signer_index = index, .signature = signature.value() });
+        }
+        std::ranges::sort(authorization.signatures, {}, &IndexedSignature::signer_index);
+        if (authorization.signatures.size() < policy.threshold) {
+            return std::unexpected(ConsensusError::InvalidGovernance);
+        }
+        return authorization;
+    }
+
+    bool verify_authorization(const MultisigPolicy&          policy,
+                              const GovernanceAuthorization& authorization,
+                              std::uint64_t                  minimum_sequence) {
+        if (!verify_multisig_policy(policy) || authorization.protocol_version != ProtocolVersion
+            || authorization.network_id != policy.network_id || authorization.sequence < minimum_sequence
+            || authorization.action_hash.empty() || authorization.signatures.size() < policy.threshold
+            || authorization.signatures.size() > policy.public_keys.size()) {
+            return false;
+        }
+        const auto              payload = authorization_payload(policy, authorization);
+        std::set<std::uint16_t> used;
+        for (const auto& item : authorization.signatures) {
+            if (item.signer_index >= policy.public_keys.size() || !used.insert(item.signer_index).second
+                || !verify_payload(policy.public_keys[item.signer_index], payload, item.signature)) {
+                return false;
+            }
+        }
+        return used.size() >= policy.threshold;
+    }
+
+    std::string epoch_change_action_hash(const EpochChangeV1& change) {
+        return unsigned_epoch_change_hash(change);
+    }
+
+    bool verify_epoch_change(const EpochChangeV1&  change,
+                             const MultisigPolicy& policy,
+                             std::uint64_t         current_height,
+                             std::uint64_t         minimum_sequence) {
+        if (change.protocol_version != ProtocolVersion || change.network_id != policy.network_id
+            || policy.public_keys.size() != GovernanceSignerCount || policy.threshold != GovernanceThreshold
+            || change.current_epoch == 0 || change.activation_epoch != change.current_epoch + 2
+            || change.activation_height <= current_height || change.current_validator_set_hash.empty()
+            || change.next_validator_set_hash.empty() || change.registry_document_hash.empty()
+            || change.authorization.action_hash != unsigned_epoch_change_hash(change)
+            || change.operators.size() != ShadowCommitteeSize) {
+            return false;
+        }
+        std::set<std::string> operator_ids;
+        std::set<ActorId>     actor_ids;
+        std::set<std::string> node_ids;
+        std::set<std::string> consensus_keys;
+        for (const auto& item : change.operators) {
+            if (item.operator_id_hash.empty() || item.actor_id.is_zero() || item.node_identifier.empty()
+                || item.consensus_public_key.empty() || item.document_hash.empty() || item.policy_version == 0
+                || !operator_ids.insert(item.operator_id_hash).second || !actor_ids.insert(item.actor_id).second
+                || !node_ids.insert(item.node_identifier).second
+                || !consensus_keys.insert(item.consensus_public_key).second) {
+                return false;
+            }
+        }
+        return verify_authorization(policy, change.authorization, minimum_sequence);
+    }
+
+    std::expected<EpochBootstrapV1, ConsensusError> make_epoch_bootstrap(
+        const EpochChangeV1&               change,
+        const ValidatorSet&                next_validators,
+        const TransactionInclusionProofV1& proof) {
+        const auto& finalized  = proof.finality_proof.finalized_proposal;
+        const auto& grandchild = proof.finality_proof.grandchild_proposal;
+        if (proof.transaction_hash != epoch_change_action_hash(change) || proof.height != finalized.header.height
+            || proof.epoch != change.current_epoch || proof.network_id != change.network_id
+            || change.activation_height != proof.height + 3
+            || proof.finality_proof.decision_certificate.height + 1 != change.activation_height
+            || proof.finality_proof.decision_certificate.header_hash != hash_header(grandchild.header)
+            || finalized.batch.last_section == std::numeric_limits<std::uint64_t>::max()
+            || next_validators.network_id != change.network_id || next_validators.epoch != change.activation_epoch
+            || hash_validator_set(next_validators) != change.next_validator_set_hash) {
+            return std::unexpected(ConsensusError::InvalidEpoch);
+        }
+        return EpochBootstrapV1 {
+            .network_id                         = change.network_id,
+            .previous_epoch                     = change.current_epoch,
+            .epoch                              = change.activation_epoch,
+            .activation_height                  = change.activation_height,
+            .previous_finalized_height          = proof.height,
+            .first_dag_section                  = finalized.batch.last_section + 1,
+            .previous_section_root              = finalized.header.section_root,
+            .previous_state_commitment          = finalized.header.state_commitment,
+            .previous_decision_certificate_hash = hash_certificate(proof.finality_proof.decision_certificate),
+            .epoch_change_hash                  = epoch_change_action_hash(change),
+            .validator_set_hash                 = hash_validator_set(next_validators),
+        };
+    }
+
+    std::string hash_epoch_bootstrap(const EpochBootstrapV1& bootstrap) {
+        return domain_hash(EpochBootstrapDomain, bootstrap);
+    }
+
+    bool verify_epoch_bootstrap(const EpochBootstrapV1& bootstrap, const ValidatorSet& next_validators) {
+        return bootstrap.protocol_version == ProtocolVersion && !bootstrap.network_id.is_zero()
+               && bootstrap.previous_epoch + 2 == bootstrap.epoch && bootstrap.activation_height >= 3
+               && bootstrap.previous_finalized_height + 3 == bootstrap.activation_height
+               && bootstrap.first_dag_section != 0 && !bootstrap.previous_section_root.empty()
+               && !bootstrap.previous_state_commitment.empty()
+               && !bootstrap.previous_decision_certificate_hash.empty() && !bootstrap.epoch_change_hash.empty()
+               && next_validators.protocol_version == ProtocolVersion
+               && next_validators.network_id == bootstrap.network_id && next_validators.epoch == bootstrap.epoch
+               && bootstrap.validator_set_hash == hash_validator_set(next_validators);
+    }
+
+    std::string recovery_action_hash(const RecoveryDocumentV1& recovery) {
+        return unsigned_recovery_hash(recovery);
+    }
+
+    bool verify_recovery_document(const RecoveryDocumentV1& recovery,
+                                  const MultisigPolicy&     recovery_policy,
+                                  std::uint64_t             expected_sequence,
+                                  std::uint64_t             expected_finalized_height,
+                                  std::string_view          expected_checkpoint_hash) {
+        return recovery.protocol_version == ProtocolVersion && recovery.network_id == recovery_policy.network_id
+               && recovery_policy.public_keys.size() == GovernanceSignerCount
+               && recovery_policy.threshold == RecoveryThreshold && recovery.recovery_sequence == expected_sequence
+               && recovery.finalized_height == expected_finalized_height
+               && recovery.finalized_checkpoint_hash == expected_checkpoint_hash
+               && !recovery.next_validator_set_hash.empty() && !recovery.registry_document_hash.empty()
+               && recovery.authorization.action_hash == unsigned_recovery_hash(recovery)
+               && recovery.authorization.sequence == recovery.recovery_sequence
+               && verify_authorization(recovery_policy, recovery.authorization, expected_sequence);
+    }
+
+    std::string activation_action_hash(const ActivationManifestV1& activation) {
+        return unsigned_activation_hash(activation);
+    }
+
+    bool verify_activation_manifest(const ActivationManifestV1& activation,
+                                    const MultisigPolicy&       policy,
+                                    std::uint64_t               current_height,
+                                    std::uint64_t               minimum_sequence) {
+        return activation.protocol_version == ProtocolVersion && activation.network_id == policy.network_id
+               && policy.public_keys.size() == GovernanceSignerCount && policy.threshold == GovernanceThreshold
+               && activation.activation_height > current_height && activation.activation_dag_section != 0
+               && activation.activation_dag_section % ShadowSectionInterval == 0
+               && !activation.validator_set_hash.empty() && activation.require_intent_v2
+               && activation.authorization.action_hash == unsigned_activation_hash(activation)
+               && verify_authorization(policy, activation.authorization, minimum_sequence);
+    }
+
+    std::string hash_state_commitment(const StateCommitmentV2& commitment) {
+        return domain_hash(StateDomain, commitment);
+    }
+
+} // namespace ExtraChain::Consensus

--- a/sources/consensus/consensus_service.cpp
+++ b/sources/consensus/consensus_service.cpp
@@ -12,6 +12,7 @@
 
 #include <charconv>
 
+#include "chain/actor_index.h"
 #include "chain/dag.h"
 #include "core/extrachain_node.h"
 #include "network/network_service.h"
@@ -19,6 +20,7 @@
 #include "network/responder.h"
 #include "utils/exc_logs.h"
 #include "utils/exc_utils.h"
+#include "utils/exc_utils_base64.h"
 #include "utils/serialization.h"
 
 namespace ExtraChain::Consensus {
@@ -45,23 +47,84 @@ namespace ExtraChain::Consensus {
         if (!loaded.has_value()) {
             return std::unexpected(loaded.error());
         }
-        consensus_            = std::move(loaded.value());
+        consensus_    = std::move(loaded.value());
+        intent_store_ = std::make_unique<IntentStore>(directory_ / "intent-pool.sqlite");
+        if (!intent_store_->open().has_value()) {
+            consensus_.reset();
+            intent_store_.reset();
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        const auto committed_nonces = intent_store_->load_committed_nonces();
+        if (!committed_nonces.has_value()) {
+            consensus_.reset();
+            intent_store_.reset();
+            return std::unexpected(committed_nonces.error());
+        }
+        committed_nonces_     = committed_nonces.value();
         const auto reconciled = reconcile_finalized_checkpoint();
         if (!reconciled.has_value()) {
             consensus_.reset();
+            intent_store_.reset();
             return std::unexpected(reconciled.error());
+        }
+        const auto epoch_activated = consensus_->activate_scheduled_epoch();
+        if (!epoch_activated.has_value()) {
+            consensus_.reset();
+            intent_store_.reset();
+            return std::unexpected(epoch_activated.error());
         }
         if (consensus_->engine().identity().has_value()) {
             const auto* local_validator =
                 consensus_->engine().validators().find(consensus_->engine().identity().value().validator_id);
             if (local_validator == nullptr || local_validator->node_identifier != node_.node_identifier()) {
                 consensus_.reset();
+                intent_store_.reset();
                 return std::unexpected(ConsensusError::InvalidValidator);
             }
         }
-        authenticator_ = std::make_unique<PeerAuthenticator>(consensus_->engine().validators(),
+        const auto pending_intents = intent_store_->load_pending();
+        if (!pending_intents.has_value()) {
+            consensus_.reset();
+            intent_store_.reset();
+            return std::unexpected(pending_intents.error());
+        }
+        std::vector<std::string> expired_intents;
+        for (const auto& envelope : pending_intents.value()) {
+            const auto actor = node_.actor_index()->read_actor(envelope.intent.sender, ActorGetType::NoRequest);
+            if (!actor.has_value()) {
+                eWarning("[Shadow] Pending intent {} waits for sender data", hash_intent(envelope.intent));
+                continue;
+            }
+            const auto accepted = intent_pool_.submit(envelope,
+                                                      Utils::to_base64(actor.value().key().public_key()),
+                                                      committed_nonces_[envelope.intent.sender],
+                                                      intent_height());
+            if (!accepted.has_value() && accepted.error() == ConsensusError::IntentExpired) {
+                expired_intents.push_back(hash_intent(envelope.intent));
+            } else if (!accepted.has_value()) {
+                consensus_.reset();
+                intent_store_.reset();
+                intent_pool_ = IntentPool {};
+                return std::unexpected(accepted.error());
+            } else if (!intent_store_->put(envelope).has_value()) {
+                consensus_.reset();
+                intent_store_.reset();
+                intent_pool_ = IntentPool {};
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+        }
+        if (!expired_intents.empty()) {
+            if (!intent_store_->expire(expired_intents).has_value()) {
+                consensus_.reset();
+                intent_store_.reset();
+                intent_pool_ = IntentPool {};
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+        }
+        authenticator_  = std::make_unique<PeerAuthenticator>(consensus_->engine().validators(),
                                                              consensus_->engine().identity());
-        timeout_task_  = Core::DeadlineTask::create(node_.runtime_executor(), [this] {
+        voting_enabled_ = consensus_->engine().identity().has_value();
+        timeout_task_   = Core::DeadlineTask::create(node_.runtime_executor(), [this] {
             timeout_elapsed();
         });
         connections_.emplace_back(node_.network()->socket_activated_event().subscribe(
@@ -90,6 +153,9 @@ namespace ExtraChain::Consensus {
         std::lock_guard lock(mutex_);
         connections_.clear();
         authenticator_.reset();
+        intent_store_.reset();
+        intent_pool_ = IntentPool {};
+        committed_nonces_.clear();
         if (timeout_task_) {
             timeout_task_->cancel();
         }
@@ -99,7 +165,9 @@ namespace ExtraChain::Consensus {
         latest_certificate_.reset();
         latest_timeout_certificate_.reset();
         pending_checkpoints_.clear();
+        pending_batches_.clear();
         pending_proposals_.clear();
+        voting_enabled_ = false;
     }
 
     void ConsensusService::receive_network_message(MessageType        type,
@@ -186,6 +254,13 @@ namespace ExtraChain::Consensus {
             const auto value = MessagePack::deserialize<ShadowSyncResponse>(serialized);
             if (status == MessageStatus::Response && value.has_value()) {
                 receive_sync_response(value.value(), peer_identifier);
+            }
+            break;
+        }
+        case MessageType::ConsensusIntent: {
+            const auto value = MessagePack::deserialize<IntentEnvelope>(serialized);
+            if (status == MessageStatus::NoStatus && value.has_value()) {
+                receive_intent(value.value());
             }
             break;
         }
@@ -488,7 +563,8 @@ namespace ExtraChain::Consensus {
             const auto valid = node_.dag()->validate_shadow_batch(proof.finalized_proposal,
                                                                   batch->second,
                                                                   consensus_->configuration().maximum_batch_bytes);
-            if (!valid.has_value() || !consensus_->engine().stage_batch(batch->second).has_value()) {
+            if (!valid.has_value() || !admit_batch_intents(proof.finalized_proposal, batch->second).has_value()
+                || !consensus_->engine().stage_batch(batch->second).has_value()) {
                 eWarning("[Shadow] Finality proof batch {} failed validation", finalized_hash);
                 return;
             }
@@ -520,6 +596,108 @@ namespace ExtraChain::Consensus {
         }
     }
 
+    void ConsensusService::receive_intent(const IntentEnvelope& envelope) {
+        std::lock_guard lock(mutex_);
+        const auto      accepted = accept_intent(envelope, false);
+        if (!accepted.has_value() && accepted.error() != ConsensusError::DuplicateIntent) {
+            eWarning("[Shadow] Intent {} was rejected with error {}",
+                     hash_intent(envelope.intent),
+                     std::to_underlying(accepted.error()));
+        }
+    }
+
+    std::expected<std::string, ConsensusError> ConsensusService::submit_intent(const IntentEnvelope& envelope) {
+        std::lock_guard lock(mutex_);
+        return accept_intent(envelope, true);
+    }
+
+    std::vector<IntentEnvelope> ConsensusService::ready_intents(std::size_t maximum_count,
+                                                                std::size_t maximum_bytes) const {
+        std::lock_guard lock(mutex_);
+        return consensus_ ? intent_pool_.ready(committed_nonces_, intent_height(), maximum_count, maximum_bytes)
+                          : std::vector<IntentEnvelope> {};
+    }
+
+    std::expected<std::optional<IntentReceipt>, ConsensusError> ConsensusService::intent_receipt(
+        std::string_view intent_hash) {
+        std::lock_guard lock(mutex_);
+        return intent_store_ ? intent_store_->receipt(intent_hash)
+                             : std::expected<std::optional<IntentReceipt>, ConsensusError>(
+                                   std::unexpected(ConsensusError::NotReady));
+    }
+
+    std::expected<void, ConsensusError> ConsensusService::finalize_intents(
+        const std::vector<std::pair<IntentEnvelope, IntentReceipt>>& finalized) {
+        std::lock_guard lock(mutex_);
+        if (!consensus_ || !intent_store_) {
+            return std::unexpected(ConsensusError::NotReady);
+        }
+        auto                     next_nonces = committed_nonces_;
+        std::vector<std::string> hashes;
+        hashes.reserve(finalized.size());
+        for (const auto& [envelope, receipt] : finalized) {
+            const auto hash          = hash_intent(envelope.intent);
+            const auto current_nonce = next_nonces[envelope.intent.sender];
+            if (receipt.status != IntentStatus::Finalized || receipt.intent_hash != hash
+                || envelope.intent.account_nonce > current_nonce + 1) {
+                return std::unexpected(ConsensusError::InvalidNonce);
+            }
+            if (envelope.intent.account_nonce == current_nonce + 1) {
+                next_nonces[envelope.intent.sender] = envelope.intent.account_nonce;
+            }
+            hashes.push_back(hash);
+        }
+        const auto committed = intent_store_->commit_finalized(finalized);
+        if (!committed.has_value()) {
+            return std::unexpected(committed.error());
+        }
+        committed_nonces_ = std::move(next_nonces);
+        intent_pool_.erase(hashes);
+        return {};
+    }
+
+    std::expected<std::string, ConsensusError> ConsensusService::accept_intent(const IntentEnvelope& envelope,
+                                                                               bool                  broadcast) {
+        if (!consensus_ || !intent_store_
+            || envelope.intent.network_id != consensus_->engine().validators().document().network_id) {
+            return std::unexpected(consensus_ ? ConsensusError::InvalidNetwork : ConsensusError::NotReady);
+        }
+        const auto actor = node_.actor_index()->read_actor(envelope.intent.sender, ActorGetType::NoRequest);
+        if (!actor.has_value()) {
+            return std::unexpected(ConsensusError::DataUnavailable);
+        }
+        const auto hash     = hash_intent(envelope.intent);
+        const auto accepted = intent_pool_.submit(envelope,
+                                                  Utils::to_base64(actor.value().key().public_key()),
+                                                  committed_nonces_[envelope.intent.sender],
+                                                  intent_height());
+        if (!accepted.has_value()) {
+            return accepted.error() == ConsensusError::DuplicateIntent
+                       ? std::expected<std::string, ConsensusError>(hash)
+                       : std::unexpected(accepted.error());
+        }
+        const auto stored = intent_store_->put(envelope);
+        if (!stored.has_value()) {
+            intent_pool_.erase({ hash });
+            return std::unexpected(stored.error());
+        }
+        if (broadcast) {
+            node_.network()->send_message(envelope,
+                                          MessageType::ConsensusIntent,
+                                          SendMode::Broadcast,
+                                          MessageStatus::NoStatus);
+        }
+        return hash;
+    }
+
+    std::uint64_t ConsensusService::intent_height() const noexcept {
+        if (!consensus_) {
+            return 0;
+        }
+        const auto& certificate = consensus_->engine().safety_state().highest_certificate;
+        return certificate.has_value() ? certificate.value().height + 1 : 1;
+    }
+
     bool ConsensusService::apply_certificate(const QuorumCertificate& certificate) {
         const auto finalized = consensus_->receive_certificate(certificate);
         if (!finalized.has_value()) {
@@ -532,6 +710,7 @@ namespace ExtraChain::Consensus {
         latest_certificate_ = certificate;
         if (latest_proposal_.has_value()
             && certificate.header_hash == hash_header(latest_proposal_.value().header)) {
+            pending_batches_.erase(latest_proposal_.value().batch.last_section);
             pending_checkpoints_.erase(latest_proposal_.value().batch.last_section);
         }
         reset_timeout();
@@ -544,16 +723,38 @@ namespace ExtraChain::Consensus {
                 const auto batch    = consensus_->engine().batch_for(checkpoint.header_hash);
                 if (!proposal.has_value() || !batch.has_value()) {
                     eCritical("[Shadow] Finalized batch {} is unavailable", checkpoint.header_hash);
+                    halt_voting();
                     return false;
                 }
                 const auto installed =
                     node_.dag()->install_shadow_batch(proposal.value(),
                                                       batch.value(),
-                                                      consensus_->configuration().maximum_batch_bytes);
+                                                      consensus_->configuration().maximum_batch_bytes,
+                                                      hash_certificate(certificate));
                 if (!installed.has_value()) {
                     eCritical("[Shadow] Finalized batch {} could not be installed: {}",
                               checkpoint.header_hash,
                               std::to_underlying(installed.error()));
+                    halt_voting();
+                    return false;
+                }
+                const auto finalized = finalized_intents(proposal.value(), batch.value());
+                if (!finalized.has_value() || !finalize_intents(finalized.value()).has_value()) {
+                    eCritical("[Shadow] Finalized intents for batch {} could not be committed",
+                              checkpoint.header_hash);
+                    halt_voting();
+                    return false;
+                }
+                const auto epoch_changes = process_epoch_changes(finalized.value());
+                if (!epoch_changes.has_value()) {
+                    eCritical("[Shadow] Finalized epoch change in batch {} is invalid", checkpoint.header_hash);
+                    halt_voting();
+                    return false;
+                }
+                const auto epoch_activated = activate_pending_epoch();
+                if (!epoch_activated.has_value()) {
+                    eCritical("[Shadow] Scheduled epoch could not be activated");
+                    halt_voting();
                     return false;
                 }
             }
@@ -570,8 +771,11 @@ namespace ExtraChain::Consensus {
         if (!consensus_ || consensus_->configuration().mode != ShadowMode::Finality) {
             return {};
         }
-        const auto finalized_height = consensus_->engine().safety_state().finalized_height;
-        if (finalized_height < consensus_->configuration().activation_height || finalized_height == 0) {
+        const auto finalized_height  = consensus_->engine().safety_state().finalized_height;
+        const auto activation_height = consensus_->engine().epoch_bootstrap().has_value()
+                                           ? consensus_->engine().epoch_bootstrap().value().activation_height
+                                           : consensus_->configuration().activation_height;
+        if (finalized_height < activation_height || finalized_height == 0) {
             return {};
         }
         const auto proofs = consensus_->engine().finality_proofs_after(finalized_height - 1, 1);
@@ -587,10 +791,23 @@ namespace ExtraChain::Consensus {
         if (!batch.has_value()) {
             return std::unexpected(ConsensusError::StorageFailure);
         }
-        return node_.dag()->install_shadow_batch(proposal,
-                                                 batch.value(),
-                                                 consensus_->configuration().maximum_batch_bytes,
-                                                 hash_certificate(proofs.value().front().decision_certificate));
+        const auto installed =
+            node_.dag()->install_shadow_batch(proposal,
+                                              batch.value(),
+                                              consensus_->configuration().maximum_batch_bytes,
+                                              hash_certificate(proofs.value().front().decision_certificate));
+        if (!installed.has_value()) {
+            return std::unexpected(installed.error());
+        }
+        const auto finalized = finalized_intents(proposal, batch.value());
+        if (!finalized.has_value()) {
+            return std::unexpected(finalized.error());
+        }
+        const auto intents_committed = finalize_intents(finalized.value());
+        if (!intents_committed.has_value()) {
+            return std::unexpected(intents_committed.error());
+        }
+        return process_epoch_changes(finalized.value());
     }
 
     bool ConsensusService::apply_timeout_certificate(const TimeoutCertificate& certificate) {
@@ -615,13 +832,24 @@ namespace ExtraChain::Consensus {
 
     bool ConsensusService::voting() const noexcept {
         std::lock_guard lock(mutex_);
-        return consensus_ && consensus_->engine().identity().has_value();
+        return consensus_ && voting_enabled_ && consensus_->engine().identity().has_value();
     }
 
     bool ConsensusService::controls_section(std::uint64_t section) const {
         std::lock_guard lock(mutex_);
         return consensus_ && consensus_->configuration().mode == ShadowMode::Finality
                && section >= consensus_->configuration().activation_dag_section;
+    }
+
+    bool ConsensusService::requires_intent_v2() const noexcept {
+        std::lock_guard lock(mutex_);
+        if (!consensus_ || consensus_->configuration().mode != ShadowMode::Finality
+            || !consensus_->engine().safety_state().highest_certificate.has_value()) {
+            return false;
+        }
+        const auto height = consensus_->engine().safety_state().highest_certificate.value().height;
+        return height != std::numeric_limits<std::uint64_t>::max()
+               && height + 1 >= consensus_->configuration().activation_height;
     }
 
     bool ConsensusService::repair_section(std::uint64_t section) {
@@ -657,6 +885,25 @@ namespace ExtraChain::Consensus {
         send_to_validators(request, MessageType::ConsensusSyncRequest, MessageStatus::Request);
         eWarning("[Shadow] DAG section {} waits for a finality proof", section);
         return false;
+    }
+
+    std::expected<std::optional<TransactionInclusionProofV1>, ConsensusError> ConsensusService::
+        transaction_inclusion_proof(std::string_view transaction_hash) const {
+        std::lock_guard lock(mutex_);
+        if (!consensus_) {
+            return std::unexpected(ConsensusError::NotReady);
+        }
+        return consensus_->engine().transaction_inclusion_proof(transaction_hash);
+    }
+
+    bool ConsensusService::verify_transaction_inclusion_proof(const TransactionInclusionProofV1& proof) const {
+        std::lock_guard lock(mutex_);
+        return consensus_ && consensus_->engine().verify_transaction_inclusion_proof(proof);
+    }
+
+    ConsensusMetricsSnapshot ConsensusService::metrics() const noexcept {
+        std::lock_guard lock(mutex_);
+        return consensus_ ? consensus_->engine().metrics() : ConsensusMetricsSnapshot {};
     }
 
     Core::Event<const FinalizedCheckpoint&>& ConsensusService::finalized_event() noexcept {
@@ -714,6 +961,7 @@ namespace ExtraChain::Consensus {
                                                   .batch        = batch.value().manifest,
                                                   .section_root = control.value().control,
                                               });
+        pending_batches_.insert_or_assign(section, batch.value());
         propose_checkpoint(consensus_->engine().safety_state().current_round);
     }
 
@@ -724,7 +972,15 @@ namespace ExtraChain::Consensus {
         const auto& highest = consensus_->engine().safety_state().highest_certificate.value();
         auto        target  = consensus_->configuration().activation_dag_section;
         if (highest.phase == Phase::Genesis) {
-            target = target == 0 ? ShadowSectionInterval : target;
+            if (consensus_->engine().epoch_bootstrap().has_value()) {
+                const auto first = consensus_->engine().epoch_bootstrap().value().first_dag_section;
+                if (first > std::numeric_limits<std::uint64_t>::max() - (ShadowSectionInterval - 1)) {
+                    return;
+                }
+                target = first + ShadowSectionInterval - 1;
+            } else {
+                target = target == 0 ? ShadowSectionInterval : target;
+            }
         } else {
             const auto parent = consensus_->engine().proposal_for(highest.header_hash);
             if (!parent.has_value()
@@ -734,13 +990,68 @@ namespace ExtraChain::Consensus {
             }
             target = parent.value().batch.last_section + ShadowSectionInterval;
         }
+        if (requires_intent_v2()) {
+            if (pending_checkpoints_.contains(target)) {
+                propose_checkpoint(consensus_->engine().safety_state().current_round);
+                return;
+            }
+            const auto flush_pipeline = has_unfinalized_intents();
+            const auto intents        = flush_pipeline
+                                            ? std::vector<IntentEnvelope> {}
+                                            : intent_pool_.ready(committed_nonces_,
+                                                          intent_height(),
+                                                          20 * 256,
+                                                          consensus_->configuration().maximum_batch_bytes / 2);
+            if (intents.empty() && !flush_pipeline) {
+                return;
+            }
+            const auto first = target == 0 ? SectionId(0) : SectionId(target) - CONTROL_INTERVAL_DIFF;
+            std::optional<std::string> previous_section_bytes;
+            std::string                previous_section_root;
+            if (highest.phase != Phase::Genesis) {
+                const auto parent       = consensus_->engine().proposal_for(highest.header_hash);
+                const auto parent_batch = consensus_->engine().batch_for(highest.header_hash);
+                if (!parent.has_value() || !parent_batch.has_value() || parent_batch.value().sections.empty()
+                    || parent_batch.value().sections.back().first != parent.value().batch.last_section) {
+                    halt_voting();
+                    return;
+                }
+                previous_section_bytes = parent_batch.value().sections.back().second;
+                previous_section_root  = parent.value().header.section_root;
+            }
+            auto batch = node_.dag()->build_shadow_intent_batch(first,
+                                                                SectionId(target),
+                                                                highest.height + 1,
+                                                                intents,
+                                                                {},
+                                                                std::move(previous_section_bytes),
+                                                                std::move(previous_section_root));
+            if (!batch.has_value()
+                || batch.value().manifest.payload_bytes > consensus_->configuration().maximum_batch_bytes) {
+                eWarning("[Shadow] Leader could not materialize the next intent batch");
+                return;
+            }
+            const auto section_root = node_.dag()->shadow_batch_section_root(batch.value());
+            if (!section_root.has_value()) {
+                eWarning("[Shadow] Leader could not calculate the intent batch root");
+                return;
+            }
+            pending_checkpoints_.insert_or_assign(target,
+                                                  ShadowCheckpoint {
+                                                      .batch        = batch.value().manifest,
+                                                      .section_root = section_root.value(),
+                                                  });
+            pending_batches_.insert_or_assign(target, std::move(batch.value()));
+            propose_checkpoint(consensus_->engine().safety_state().current_round);
+            return;
+        }
         if (node_.dag()->read_control(SectionId(target)).has_value()) {
             checkpoint_ready(target);
         }
     }
 
     void ConsensusService::propose_checkpoint(std::uint64_t round) {
-        if (!consensus_ || pending_checkpoints_.empty()) {
+        if (!consensus_ || !voting_enabled_ || pending_checkpoints_.empty()) {
             return;
         }
         const auto highest = consensus_->engine().safety_state().highest_certificate;
@@ -758,6 +1069,7 @@ namespace ExtraChain::Consensus {
         }
         while (!pending_checkpoints_.empty()
                && pending_checkpoints_.begin()->second.batch.last_section < next_section) {
+            pending_batches_.erase(pending_checkpoints_.begin()->first);
             pending_checkpoints_.erase(pending_checkpoints_.begin());
         }
         if (pending_checkpoints_.empty()
@@ -776,16 +1088,19 @@ namespace ExtraChain::Consensus {
         }
 
         const auto& proposal_value = proposal.value().value();
-        auto        batch          = node_.dag()->build_shadow_batch(SectionId(proposal_value.batch.first_section),
-                                                     SectionId(proposal_value.batch.last_section),
-                                                     hash_header(proposal_value.header));
-        if (!batch.has_value()
+        const auto  stored_batch   = pending_batches_.find(proposal_value.batch.last_section);
+        if (stored_batch == pending_batches_.end()) {
+            eWarning("[Shadow] Leader has no data for the proposed batch");
+            return;
+        }
+        auto batch        = stored_batch->second;
+        batch.header_hash = hash_header(proposal_value.header);
+        if (hash_batch_manifest(batch.manifest) != proposal_value.header.batch_root
             || !node_.dag()
-                    ->validate_shadow_batch(proposal_value,
-                                            batch.value(),
-                                            consensus_->configuration().maximum_batch_bytes)
+                    ->validate_shadow_batch(proposal_value, batch, consensus_->configuration().maximum_batch_bytes)
                     .has_value()
-            || !consensus_->engine().stage_batch(batch.value()).has_value()) {
+            || !admit_batch_intents(proposal_value, batch).has_value()
+            || !consensus_->engine().stage_batch(batch).has_value()) {
             eWarning("[Shadow] Leader could not stage the proposed batch");
             return;
         }
@@ -821,6 +1136,9 @@ namespace ExtraChain::Consensus {
     }
 
     void ConsensusService::vote_for_proposal(const Proposal& proposal, std::string_view peer_identifier) {
+        if (!voting_enabled_) {
+            return;
+        }
         const auto vote = consensus_->engine().accept_proposal(proposal);
         if (!vote.has_value()) {
             eWarning("[Shadow] Proposal {} at height {} was not voted for: {}",
@@ -839,7 +1157,7 @@ namespace ExtraChain::Consensus {
 
     void ConsensusService::timeout_elapsed() {
         std::lock_guard lock(mutex_);
-        if (!consensus_ || !consensus_->engine().identity().has_value()
+        if (!consensus_ || !voting_enabled_ || !consensus_->engine().identity().has_value()
             || !consensus_->engine().safety_state().highest_certificate.has_value()) {
             return;
         }
@@ -860,7 +1178,7 @@ namespace ExtraChain::Consensus {
     }
 
     void ConsensusService::reset_timeout() {
-        if (!timeout_task_ || !consensus_) {
+        if (!timeout_task_ || !consensus_ || !voting_enabled_) {
             return;
         }
         const auto& configuration = consensus_->configuration();
@@ -872,6 +1190,13 @@ namespace ExtraChain::Consensus {
         const auto  jitter = std::hash<std::string> {}(node_.node_identifier()) % 251;
         timeout_task_->schedule_after(
             std::chrono::milliseconds(std::min(configuration.maximum_timeout_ms, base + jitter)));
+    }
+
+    void ConsensusService::halt_voting() {
+        voting_enabled_ = false;
+        if (timeout_task_) {
+            timeout_task_->cancel();
+        }
     }
 
     void ConsensusService::send_to_peer(const auto&        payload,
@@ -902,9 +1227,10 @@ namespace ExtraChain::Consensus {
         }
         const auto stored = consensus_->engine().batch_for(hash_header(proposal.header));
         if (stored.has_value()) {
-            return node_.dag()->validate_shadow_batch(proposal,
-                                                      stored.value(),
-                                                      consensus_->configuration().maximum_batch_bytes);
+            const auto valid = node_.dag()->validate_shadow_batch(proposal,
+                                                                  stored.value(),
+                                                                  consensus_->configuration().maximum_batch_bytes);
+            return !valid.has_value() ? valid : admit_batch_intents(proposal, stored.value());
         }
 
         auto local = node_.dag()->build_shadow_batch(SectionId(proposal.batch.first_section),
@@ -922,7 +1248,167 @@ namespace ExtraChain::Consensus {
         if (!valid.has_value()) {
             return std::unexpected(valid.error());
         }
+        const auto admitted = admit_batch_intents(proposal, local.value());
+        if (!admitted.has_value()) {
+            return admitted;
+        }
         return consensus_->engine().stage_batch(std::move(local.value()));
+    }
+
+    bool ConsensusService::has_unfinalized_intents() const {
+        if (!consensus_) {
+            return false;
+        }
+        const auto& state = consensus_->engine().safety_state();
+        if (!state.highest_certificate.has_value()) {
+            return false;
+        }
+        auto certificate = state.highest_certificate.value();
+        while (certificate.phase != Phase::Genesis && certificate.height > state.finalized_height) {
+            const auto proposal = consensus_->engine().proposal_for(certificate.header_hash);
+            if (!proposal.has_value()) {
+                return true;
+            }
+            if (!proposal.value().batch.transaction_hashes.empty()) {
+                return true;
+            }
+            certificate = proposal.value().parent_certificate;
+        }
+        return false;
+    }
+
+    std::expected<std::vector<std::pair<IntentEnvelope, IntentReceipt>>, ConsensusError> ConsensusService::
+        finalized_intents(const Proposal& proposal, const SectionBatchData& batch) const {
+        std::vector<std::pair<IntentEnvelope, IntentReceipt>> result;
+        WireFormat::Scope                                     canonical_scope(WireFormat::Mode::Canonical);
+        for (const auto& [section, bytes] : batch.sections) {
+            const auto decoded = Json::deserialize<Section>(bytes);
+            if (!decoded.has_value()) {
+                return std::unexpected(ConsensusError::InvalidIntent);
+            }
+            std::uint32_t position = 0;
+            for (const auto& transaction : decoded.value().transactions) {
+                if (!transaction.consensus_intent().has_value()) {
+                    ++position;
+                    continue;
+                }
+                const auto envelope = intent_from_transaction(transaction);
+                if (!envelope.has_value()) {
+                    return std::unexpected(envelope.error());
+                }
+                result.emplace_back(envelope.value(),
+                                    IntentReceipt {
+                                        .intent_hash      = hash_intent(envelope.value().intent),
+                                        .status           = IntentStatus::Finalized,
+                                        .consensus_height = proposal.header.height,
+                                        .dag_section      = section,
+                                        .position         = position,
+                                        .error            = ConsensusError::NotReady,
+                                    });
+                ++position;
+            }
+        }
+        return result;
+    }
+
+    std::expected<void, ConsensusError> ConsensusService::admit_batch_intents(const Proposal&         proposal,
+                                                                              const SectionBatchData& batch) {
+        const auto finalized = finalized_intents(proposal, batch);
+        if (!finalized.has_value()) {
+            return std::unexpected(finalized.error());
+        }
+        if (proposal.header.height >= consensus_->configuration().activation_height
+            && finalized.value().size() != proposal.batch.transaction_hashes.size()) {
+            return std::unexpected(ConsensusError::InvalidIntent);
+        }
+        bool epoch_change_seen = false;
+        for (const auto& [envelope, _] : finalized.value()) {
+            if (envelope.intent.operation == IntentOperation::EpochChange) {
+                const auto bytes = Utils::from_base64(envelope.metadata);
+                if (epoch_change_seen || !bytes.has_value()
+                    || envelope.intent.receiver != consensus_->engine().validators().document().network_id) {
+                    return std::unexpected(ConsensusError::InvalidEpoch);
+                }
+                const auto request = MessagePack::deserialize<EpochChangeRequestV1>(bytes.value());
+                if (!request.has_value()
+                    || !consensus_->validate_epoch_request(request.value(), proposal.header.height).has_value()) {
+                    return std::unexpected(ConsensusError::InvalidEpoch);
+                }
+                epoch_change_seen = true;
+            }
+            const auto accepted = accept_intent(envelope, false);
+            if (!accepted.has_value() || accepted.value() != hash_intent(envelope.intent)) {
+                return std::unexpected(accepted.has_value() ? ConsensusError::InvalidIntent : accepted.error());
+            }
+        }
+        return {};
+    }
+
+    std::expected<void, ConsensusError> ConsensusService::process_epoch_changes(
+        const std::vector<std::pair<IntentEnvelope, IntentReceipt>>& finalized) {
+        for (const auto& [envelope, receipt] : finalized) {
+            if (envelope.intent.operation != IntentOperation::EpochChange) {
+                continue;
+            }
+            const auto bytes = Utils::from_base64(envelope.metadata);
+            if (!bytes.has_value()) {
+                return std::unexpected(ConsensusError::InvalidEpoch);
+            }
+            const auto request = MessagePack::deserialize<EpochChangeRequestV1>(bytes.value());
+            if (!request.has_value() || request.value().protocol_version != ProtocolVersion
+                || envelope.intent.receiver != consensus_->engine().validators().document().network_id
+                || receipt.status != IntentStatus::Finalized) {
+                return std::unexpected(ConsensusError::InvalidEpoch);
+            }
+            const auto action_hash = epoch_change_action_hash(request.value().change);
+            if (consensus_->pending_epoch().has_value()
+                && consensus_->pending_epoch().value().bootstrap.epoch_change_hash == action_hash) {
+                continue;
+            }
+            const auto proof = consensus_->engine().transaction_inclusion_proof(action_hash);
+            if (!proof.has_value() || !proof.value().has_value()) {
+                return std::unexpected(ConsensusError::InvalidProof);
+            }
+            const auto scheduled = consensus_->schedule_epoch(request.value().change,
+                                                              request.value().next_validators,
+                                                              proof.value().value());
+            if (!scheduled.has_value()) {
+                return std::unexpected(scheduled.error());
+            }
+        }
+        return {};
+    }
+
+    std::expected<bool, ConsensusError> ConsensusService::activate_pending_epoch() {
+        const auto activated = consensus_->activate_scheduled_epoch();
+        if (!activated.has_value()) {
+            halt_voting();
+            return std::unexpected(activated.error());
+        }
+        if (!activated.value()) {
+            return activated;
+        }
+        if (consensus_->engine().identity().has_value()) {
+            const auto* local =
+                consensus_->engine().validators().find(consensus_->engine().identity().value().validator_id);
+            if (local == nullptr || local->node_identifier != node_.node_identifier()) {
+                return std::unexpected(ConsensusError::InvalidValidator);
+            }
+        }
+        authenticator_  = std::make_unique<PeerAuthenticator>(consensus_->engine().validators(),
+                                                             consensus_->engine().identity());
+        voting_enabled_ = consensus_->engine().identity().has_value();
+        latest_proposal_.reset();
+        latest_certificate_.reset();
+        latest_timeout_certificate_.reset();
+        pending_checkpoints_.clear();
+        pending_batches_.clear();
+        pending_proposals_.clear();
+        reset_timeout();
+        eInfo("[Shadow] Activated validator epoch {} at height {}",
+              consensus_->engine().validators().document().epoch,
+              consensus_->engine().genesis_certificate().height + 1);
+        return true;
     }
 
 } // namespace ExtraChain::Consensus

--- a/sources/consensus/consensus_types.cpp
+++ b/sources/consensus/consensus_types.cpp
@@ -25,12 +25,15 @@ namespace ExtraChain::Consensus {
         constexpr std::string_view ValidatorSetDomain       = "EXC_CONSENSUS_VALIDATOR_SET_V1";
         constexpr std::string_view HeaderDomain             = "EXC_CONSENSUS_HEADER_V1";
         constexpr std::string_view BatchDomain              = "EXC_SHADOW_BATCH_V1";
-        constexpr std::string_view TransactionRootDomain    = "EXC_SHADOW_TRANSACTION_ROOT_V1";
+        constexpr std::string_view TransactionLeafDomain    = "EXC_SHADOW_TRANSACTION_LEAF_V2";
+        constexpr std::string_view TransactionNodeDomain    = "EXC_SHADOW_TRANSACTION_NODE_V2";
+        constexpr std::string_view TransactionEmptyDomain   = "EXC_SHADOW_TRANSACTION_EMPTY_V2";
         constexpr std::string_view DataRootDomain           = "EXC_SHADOW_DATA_ROOT_V1";
         constexpr std::string_view ProposalDomain           = "EXC_CONSENSUS_PROPOSAL_V1";
         constexpr std::string_view VoteDomain               = "EXC_CONSENSUS_VOTE_V1";
         constexpr std::string_view TimeoutVoteDomain        = "EXC_SHADOW_TIMEOUT_VOTE_V1";
         constexpr std::string_view CertificateDomain        = "EXC_CONSENSUS_CERTIFICATE_V1";
+        constexpr std::string_view StateDomain              = "EXC_CONSENSUS_STATE_V1";
         constexpr std::string_view TimeoutCertificateDomain = "EXC_SHADOW_TIMEOUT_CERTIFICATE_V1";
         constexpr std::string_view ChallengeDomain          = "EXC_CONSENSUS_AUTH_CHALLENGE_V1";
         constexpr std::string_view AuthResponseDomain       = "EXC_CONSENSUS_AUTH_RESPONSE_V1";
@@ -94,7 +97,26 @@ namespace ExtraChain::Consensus {
     }
 
     std::string calculate_transaction_root(const std::vector<std::string>& hashes) {
-        return domain_hash(TransactionRootDomain, hashes);
+        if (hashes.empty()) {
+            return Utils::calculate_hash(std::string(TransactionEmptyDomain), Utils::HashAlgorithm::Blake3);
+        }
+        std::vector<std::string> level;
+        level.reserve(hashes.size());
+        for (const auto& hash : hashes) {
+            level.push_back(
+                Utils::calculate_hash(std::string(TransactionLeafDomain) + hash, Utils::HashAlgorithm::Blake3));
+        }
+        while (level.size() > 1) {
+            std::vector<std::string> next;
+            next.reserve((level.size() + 1) / 2);
+            for (std::size_t index = 0; index < level.size(); index += 2) {
+                const auto& right = index + 1 < level.size() ? level[index + 1] : level[index];
+                next.push_back(Utils::calculate_hash(std::string(TransactionNodeDomain) + level[index] + right,
+                                                     Utils::HashAlgorithm::Blake3));
+            }
+            level = std::move(next);
+        }
+        return level.front();
     }
 
     std::string calculate_data_root(const std::vector<std::pair<std::uint64_t, std::string>>& sections) {
@@ -108,6 +130,16 @@ namespace ExtraChain::Consensus {
 
     std::string hash_certificate(const QuorumCertificate& certificate) {
         return domain_hash(CertificateDomain, certificate);
+    }
+
+    std::string calculate_consensus_state_commitment(const QuorumCertificate& parent,
+                                                     std::string_view         section_root,
+                                                     std::string_view         batch_root,
+                                                     std::string_view         validator_set_hash) {
+        return Utils::calculate_hash(std::string(StateDomain) + hash_certificate(parent)
+                                         + std::string(section_root) + std::string(batch_root)
+                                         + std::string(validator_set_hash),
+                                     Utils::HashAlgorithm::Blake3);
     }
 
     std::string hash_timeout_certificate(const TimeoutCertificate& certificate) {

--- a/sources/consensus/intent_store.cpp
+++ b/sources/consensus/intent_store.cpp
@@ -1,0 +1,348 @@
+/*
+ * ExtraChain Core
+ * Copyright (C) 2025 ExtraChain Foundation <official@extrachain.io>
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, Inc., either version 3 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "consensus/intent_store.h"
+
+#include <algorithm>
+#include <charconv>
+#include <limits>
+
+#include "utils/db_connector.h"
+#include "utils/exc_utils_base64.h"
+#include "utils/serialization.h"
+
+namespace ExtraChain::Consensus {
+    namespace {
+        constexpr std::string_view CreateIntentTable =
+            "CREATE TABLE IF NOT EXISTS consensus_intents (hash TEXT PRIMARY KEY, sender TEXT NOT NULL, "
+            "nonce INTEGER NOT NULL, expires_height INTEGER NOT NULL, payload TEXT NOT NULL)";
+        constexpr std::string_view CreateSenderNonceIndex =
+            "CREATE UNIQUE INDEX IF NOT EXISTS consensus_intents_sender_nonce "
+            "ON consensus_intents(sender, nonce)";
+        constexpr std::string_view CreateExpiryIndex =
+            "CREATE INDEX IF NOT EXISTS consensus_intents_expiry ON consensus_intents(expires_height)";
+        constexpr std::string_view CreateReceiptTable =
+            "CREATE TABLE IF NOT EXISTS consensus_intent_receipts (hash TEXT PRIMARY KEY, payload TEXT NOT NULL)";
+        constexpr std::string_view CreateNonceTable =
+            "CREATE TABLE IF NOT EXISTS consensus_intent_nonces (sender TEXT PRIMARY KEY, nonce INTEGER NOT NULL)";
+
+        template <typename T>
+        std::string encode(const T& value) {
+            return Utils::to_base64(MessagePack::serialize(value));
+        }
+
+        template <typename T>
+        std::expected<T, ConsensusError> decode(std::string_view encoded) {
+            const auto bytes = Utils::from_base64(std::string(encoded));
+            if (!bytes.has_value()) {
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+            const auto value = MessagePack::deserialize<T>(bytes.value());
+            return value.has_value() ? std::expected<T, ConsensusError>(std::move(value.value()))
+                                     : std::unexpected(ConsensusError::StorageFailure);
+        }
+    } // namespace
+
+    IntentStore::IntentStore(std::filesystem::path database_path)
+        : database_path_(std::move(database_path)) {
+    }
+
+    IntentStore::~IntentStore() = default;
+
+    std::expected<void, ConsensusError> IntentStore::open() {
+        std::lock_guard lock(mutex_);
+        if (database_ && database_->is_open()) {
+            return {};
+        }
+        std::error_code error;
+        if (!database_path_.parent_path().empty()) {
+            std::filesystem::create_directories(database_path_.parent_path(), error);
+        }
+        if (error) {
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        database_ = std::make_unique<DbConnector>(database_path_);
+        if (!database_->open()) {
+            database_.reset();
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        const auto journal_mode = database_->select("PRAGMA journal_mode=WAL");
+        if (journal_mode.size() != 1 || !journal_mode.front().contains("journal_mode")
+            || journal_mode.front().at("journal_mode") != "wal" || !database_->query("PRAGMA synchronous=FULL")
+            || !database_->query(std::string(CreateIntentTable))
+            || !database_->query(std::string(CreateSenderNonceIndex))
+            || !database_->query(std::string(CreateExpiryIndex))
+            || !database_->query(std::string(CreateReceiptTable))
+            || !database_->query(std::string(CreateNonceTable))) {
+            database_.reset();
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        const auto integrity = database_->select("PRAGMA quick_check");
+        if (integrity.size() != 1 || !integrity.front().contains("quick_check")
+            || integrity.front().at("quick_check") != "ok") {
+            database_.reset();
+            return std::unexpected(ConsensusError::StorageFailure);
+        }
+        return {};
+    }
+
+    std::expected<void, ConsensusError> IntentStore::put(const IntentEnvelope& envelope) {
+        std::lock_guard lock(mutex_);
+        if (!database_ || !database_->is_open()) {
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        const auto     hash            = hash_intent(envelope.intent);
+        constexpr auto maximum_integer = static_cast<std::uint64_t>(std::numeric_limits<std::int64_t>::max());
+        if (envelope.intent.account_nonce > maximum_integer
+            || envelope.intent.expires_after_height > maximum_integer) {
+            return std::unexpected(ConsensusError::InvalidIntent);
+        }
+        if (!database_->query("BEGIN IMMEDIATE TRANSACTION")) {
+            return std::unexpected(ConsensusError::StorageFailure);
+        }
+        const auto fail = [&](ConsensusError error) -> std::expected<void, ConsensusError> {
+            database_->query("ROLLBACK");
+            return std::unexpected(error);
+        };
+        const auto encoded    = encode(envelope);
+        const auto hash_match = database_->select("SELECT hash, payload FROM consensus_intents WHERE hash = ?",
+                                                  "consensus_intents",
+                                                  { { "hash", hash } });
+        if (!hash_match.empty()) {
+            if (hash_match.size() != 1 || !hash_match.front().contains("payload")
+                || hash_match.front().at("payload") != encoded) {
+                return fail(ConsensusError::DuplicateIntent);
+            }
+            const auto receipts = database_->select("SELECT payload FROM consensus_intent_receipts WHERE hash = ?",
+                                                    "consensus_intent_receipts",
+                                                    { { "hash", hash } });
+            const IntentReceipt accepted { .intent_hash = hash, .status = IntentStatus::Accepted };
+            if ((!receipts.empty()
+                 && (receipts.size() != 1 || !receipts.front().contains("payload")
+                     || receipts.front().at("payload") != encode(accepted)))
+                || (receipts.empty()
+                    && !database_->replace("consensus_intent_receipts",
+                                           { { "hash", hash }, { "payload", encode(accepted) } }))) {
+                return fail(ConsensusError::StorageFailure);
+            }
+            if (!database_->query("COMMIT")) {
+                return fail(ConsensusError::StorageFailure);
+            }
+            return {};
+        }
+        const auto sender_matches = database_->select("SELECT hash, nonce FROM consensus_intents WHERE sender = ?",
+                                                      "consensus_intents",
+                                                      { { "sender", envelope.intent.sender.to_string() } });
+        const auto nonce          = std::to_string(envelope.intent.account_nonce);
+        if (std::ranges::any_of(sender_matches, [&nonce](const DbRow& row) {
+                return row.contains("nonce") && row.at("nonce") == nonce;
+            })) {
+            return fail(ConsensusError::DuplicateIntent);
+        }
+        const IntentReceipt accepted { .intent_hash = hash, .status = IntentStatus::Accepted };
+        if (!database_->insert("consensus_intents",
+                               { { "hash", hash },
+                                 { "sender", envelope.intent.sender.to_string() },
+                                 { "nonce", std::to_string(envelope.intent.account_nonce) },
+                                 { "expires_height", std::to_string(envelope.intent.expires_after_height) },
+                                 { "payload", encoded } })
+            || !database_->replace("consensus_intent_receipts",
+                                   { { "hash", hash }, { "payload", encode(accepted) } })
+            || !database_->query("COMMIT")) {
+            return fail(ConsensusError::StorageFailure);
+        }
+        return {};
+    }
+
+    std::expected<void, ConsensusError> IntentStore::erase(const std::vector<std::string>& intent_hashes) {
+        std::lock_guard lock(mutex_);
+        if (!database_ || !database_->is_open()) {
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        if (!database_->query("BEGIN IMMEDIATE TRANSACTION")) {
+            return std::unexpected(ConsensusError::StorageFailure);
+        }
+        for (const auto& hash : intent_hashes) {
+            if (!database_->delete_row("consensus_intents", { { "hash", hash } })) {
+                database_->query("ROLLBACK");
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+        }
+        if (!database_->query("COMMIT")) {
+            database_->query("ROLLBACK");
+            return std::unexpected(ConsensusError::StorageFailure);
+        }
+        return {};
+    }
+
+    std::expected<void, ConsensusError> IntentStore::expire(const std::vector<std::string>& intent_hashes) {
+        std::lock_guard lock(mutex_);
+        if (!database_ || !database_->is_open()) {
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        if (intent_hashes.empty()) {
+            return {};
+        }
+        if (!database_->query("BEGIN IMMEDIATE TRANSACTION")) {
+            return std::unexpected(ConsensusError::StorageFailure);
+        }
+        for (const auto& hash : intent_hashes) {
+            const IntentReceipt receipt {
+                .intent_hash = hash,
+                .status      = IntentStatus::Expired,
+                .error       = ConsensusError::IntentExpired,
+            };
+            if (!database_->replace("consensus_intent_receipts",
+                                    { { "hash", hash }, { "payload", encode(receipt) } })
+                || !database_->delete_row("consensus_intents", { { "hash", hash } })) {
+                database_->query("ROLLBACK");
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+        }
+        if (!database_->query("COMMIT")) {
+            database_->query("ROLLBACK");
+            return std::unexpected(ConsensusError::StorageFailure);
+        }
+        return {};
+    }
+
+    std::expected<std::vector<IntentEnvelope>, ConsensusError> IntentStore::load_pending() {
+        std::lock_guard lock(mutex_);
+        if (!database_ || !database_->is_open()) {
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        std::vector<IntentEnvelope> result;
+        const auto                  rows =
+            database_->select("SELECT payload FROM consensus_intents ORDER BY sender ASC, nonce ASC");
+        result.reserve(rows.size());
+        for (const auto& row : rows) {
+            if (!row.contains("payload")) {
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+            auto envelope = decode<IntentEnvelope>(row.at("payload"));
+            if (!envelope.has_value()) {
+                return std::unexpected(envelope.error());
+            }
+            result.push_back(std::move(envelope.value()));
+        }
+        return result;
+    }
+
+    std::expected<std::map<ActorId, std::uint64_t>, ConsensusError> IntentStore::load_committed_nonces() {
+        std::lock_guard lock(mutex_);
+        if (!database_ || !database_->is_open()) {
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        std::map<ActorId, std::uint64_t> result;
+        for (const auto& row : database_->select("SELECT sender, nonce FROM consensus_intent_nonces")) {
+            if (!row.contains("sender") || !row.contains("nonce")) {
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+            const auto    sender     = ActorId::create(row.at("sender"));
+            std::uint64_t nonce      = 0;
+            const auto&   nonce_text = row.at("nonce");
+            const auto parsed = std::from_chars(nonce_text.data(), nonce_text.data() + nonce_text.size(), nonce);
+            if (!sender.has_value() || parsed.ec != std::errc {}
+                || parsed.ptr != nonce_text.data() + nonce_text.size()) {
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+            result.emplace(sender.value(), nonce);
+        }
+        return result;
+    }
+
+    std::expected<void, ConsensusError> IntentStore::commit_finalized(
+        const std::vector<std::pair<IntentEnvelope, IntentReceipt>>& finalized) {
+        std::lock_guard lock(mutex_);
+        if (!database_ || !database_->is_open()) {
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        if (finalized.empty()) {
+            return {};
+        }
+        std::map<ActorId, std::uint64_t> committed_nonces;
+        for (const auto& row : database_->select("SELECT sender, nonce FROM consensus_intent_nonces")) {
+            if (!row.contains("sender") || !row.contains("nonce")) {
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+            const auto    sender     = ActorId::create(row.at("sender"));
+            std::uint64_t nonce      = 0;
+            const auto&   nonce_text = row.at("nonce");
+            const auto parsed = std::from_chars(nonce_text.data(), nonce_text.data() + nonce_text.size(), nonce);
+            if (!sender.has_value() || parsed.ec != std::errc {}
+                || parsed.ptr != nonce_text.data() + nonce_text.size()) {
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+            committed_nonces.emplace(sender.value(), nonce);
+        }
+        if (!database_->query("BEGIN IMMEDIATE TRANSACTION")) {
+            return std::unexpected(ConsensusError::StorageFailure);
+        }
+        for (const auto& [envelope, receipt] : finalized) {
+            const auto hash    = hash_intent(envelope.intent);
+            const auto pending = database_->select("SELECT payload FROM consensus_intents WHERE hash = ?",
+                                                   "consensus_intents",
+                                                   { { "hash", hash } });
+            if (envelope.intent.account_nonce <= committed_nonces[envelope.intent.sender]) {
+                const auto stored_receipt =
+                    database_->select("SELECT payload FROM consensus_intent_receipts WHERE hash = ?",
+                                      "consensus_intent_receipts",
+                                      { { "hash", hash } });
+                if (!pending.empty() || stored_receipt.size() != 1 || !stored_receipt.front().contains("payload")
+                    || stored_receipt.front().at("payload") != encode(receipt)) {
+                    database_->query("ROLLBACK");
+                    return std::unexpected(ConsensusError::StorageFailure);
+                }
+                continue;
+            }
+            if (receipt.status != IntentStatus::Finalized || receipt.intent_hash != hash
+                || envelope.intent.account_nonce != committed_nonces[envelope.intent.sender] + 1
+                || pending.size() != 1 || !pending.front().contains("payload")
+                || pending.front().at("payload") != encode(envelope)
+                || !database_->replace("consensus_intent_receipts",
+                                       { { "hash", hash }, { "payload", encode(receipt) } })
+                || !database_->replace("consensus_intent_nonces",
+                                       { { "sender", envelope.intent.sender.to_string() },
+                                         { "nonce", std::to_string(envelope.intent.account_nonce) } })
+                || !database_->delete_row("consensus_intents", { { "hash", hash } })) {
+                database_->query("ROLLBACK");
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+            committed_nonces[envelope.intent.sender] = envelope.intent.account_nonce;
+        }
+        if (!database_->query("COMMIT")) {
+            database_->query("ROLLBACK");
+            return std::unexpected(ConsensusError::StorageFailure);
+        }
+        return {};
+    }
+
+    std::expected<std::optional<IntentReceipt>, ConsensusError> IntentStore::receipt(
+        std::string_view intent_hash) {
+        std::lock_guard lock(mutex_);
+        if (!database_ || !database_->is_open()) {
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        const auto rows = database_->select("SELECT payload FROM consensus_intent_receipts WHERE hash = ?",
+                                            "consensus_intent_receipts",
+                                            { { "hash", std::string(intent_hash) } });
+        if (rows.empty()) {
+            return std::optional<IntentReceipt> {};
+        }
+        if (rows.size() != 1 || !rows.front().contains("payload")) {
+            return std::unexpected(ConsensusError::StorageFailure);
+        }
+        auto value = decode<IntentReceipt>(rows.front().at("payload"));
+        return value.has_value()
+                   ? std::expected<std::optional<IntentReceipt>, ConsensusError>(std::move(value.value()))
+                   : std::unexpected(value.error());
+    }
+
+} // namespace ExtraChain::Consensus

--- a/sources/consensus/light_client.cpp
+++ b/sources/consensus/light_client.cpp
@@ -1,0 +1,436 @@
+/*
+ * ExtraChain Core
+ * Copyright (C) 2025 ExtraChain Foundation <official@extrachain.io>
+ *
+ * This library is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published
+ * by the Free Software Foundation, Inc., either version 3 of the License,
+ * or (at your option) any later version.
+ */
+
+#include "consensus/light_client.h"
+
+#include <bit>
+#include <limits>
+
+#include "utils/file_io.h"
+#include "utils/serialization.h"
+
+namespace ExtraChain::Consensus {
+    namespace {
+        bool bit_is_set(const std::vector<std::uint8_t>& bitmap, std::size_t index) {
+            return (bitmap[index / 8] & static_cast<std::uint8_t>(1U << (index % 8))) != 0;
+        }
+
+        std::size_t bit_count(const std::vector<std::uint8_t>& bitmap) {
+            std::size_t count = 0;
+            for (const auto byte : bitmap) {
+                count += std::popcount(byte);
+            }
+            return count;
+        }
+
+        bool active_at(const ValidatorRecord& validator, std::uint64_t height) {
+            return validator.status == ValidatorStatus::Active && validator.valid_from <= height
+                   && (validator.valid_until == 0 || height < validator.valid_until);
+        }
+
+        bool verify_certificate(const QuorumCertificate& certificate,
+                                const ValidatorSetView&  validators,
+                                const EpochBootstrapV1*  bootstrap = nullptr) {
+            if (certificate.protocol_version != ProtocolVersion
+                || certificate.network_id != validators.document().network_id
+                || certificate.epoch != validators.document().epoch || certificate.header_hash.empty()) {
+                return false;
+            }
+            if (certificate.phase == Phase::Genesis) {
+                const auto expected = bootstrap == nullptr
+                                          ? make_genesis_certificate(validators)
+                                          : make_epoch_genesis_certificate(validators, *bootstrap);
+                return certificate.height == expected.height && certificate.round == 0
+                       && certificate.signatures.empty()
+                       && certificate.signer_bitmap
+                              == std::vector<std::uint8_t>((validators.active().size() + 7) / 8, 0)
+                       && certificate.header_hash == expected.header_hash;
+            }
+            if (certificate.phase != Phase::Prepare
+                || certificate.signer_bitmap.size() != (validators.active().size() + 7) / 8
+                || bit_count(certificate.signer_bitmap) != certificate.signatures.size()
+                || certificate.signatures.size() < validators.quorum()) {
+                return false;
+            }
+            if (validators.active().size() % 8 != 0) {
+                const auto valid_bits = static_cast<std::uint8_t>((1U << (validators.active().size() % 8)) - 1U);
+                if ((certificate.signer_bitmap.back() & static_cast<std::uint8_t>(~valid_bits)) != 0) {
+                    return false;
+                }
+            }
+            std::size_t signature_index = 0;
+            for (std::size_t index = 0; index < validators.active().size(); ++index) {
+                if (!bit_is_set(certificate.signer_bitmap, index)) {
+                    continue;
+                }
+                const auto& validator = validators.active()[index];
+                const Vote  vote {
+                     .protocol_version = certificate.protocol_version,
+                     .network_id       = certificate.network_id,
+                     .epoch            = certificate.epoch,
+                     .height           = certificate.height,
+                     .round            = certificate.round,
+                     .phase            = certificate.phase,
+                     .header_hash      = certificate.header_hash,
+                     .validator_id     = validator.validator_id,
+                     .signature        = certificate.signatures[signature_index++],
+                };
+                if (!active_at(validator, vote.height)
+                    || !verify_payload(validator.consensus_public_key,
+                                       vote_signing_payload(vote),
+                                       vote.signature)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        bool verify_timeout_certificate(const TimeoutCertificate& certificate,
+                                        const ValidatorSetView&   validators,
+                                        const EpochBootstrapV1*   bootstrap) {
+            if (certificate.protocol_version != ProtocolVersion
+                || certificate.network_id != validators.document().network_id
+                || certificate.epoch != validators.document().epoch || certificate.height == 0
+                || certificate.height != certificate.highest_certificate.height + 1
+                || !verify_certificate(certificate.highest_certificate, validators, bootstrap)
+                || certificate.signer_bitmap.size() != (validators.active().size() + 7) / 8
+                || bit_count(certificate.signer_bitmap) != certificate.signatures.size()
+                || certificate.signatures.size() < validators.quorum()) {
+                return false;
+            }
+            if (validators.active().size() % 8 != 0) {
+                const auto valid_bits = static_cast<std::uint8_t>((1U << (validators.active().size() % 8)) - 1U);
+                if ((certificate.signer_bitmap.back() & static_cast<std::uint8_t>(~valid_bits)) != 0) {
+                    return false;
+                }
+            }
+            std::size_t signature_index = 0;
+            for (std::size_t index = 0; index < validators.active().size(); ++index) {
+                if (!bit_is_set(certificate.signer_bitmap, index)) {
+                    continue;
+                }
+                const auto&       validator = validators.active()[index];
+                const TimeoutVote vote {
+                    .protocol_version         = certificate.protocol_version,
+                    .network_id               = certificate.network_id,
+                    .epoch                    = certificate.epoch,
+                    .height                   = certificate.height,
+                    .round                    = certificate.round,
+                    .highest_certificate_hash = hash_certificate(certificate.highest_certificate),
+                    .validator_id             = validator.validator_id,
+                    .signature                = certificate.signatures[signature_index++],
+                };
+                if (!active_at(validator, vote.height)
+                    || !verify_payload(validator.consensus_public_key,
+                                       timeout_vote_signing_payload(vote),
+                                       vote.signature)) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        std::string state_commitment(const Proposal& proposal, const ValidatorSetView& validators) {
+            return calculate_consensus_state_commitment(proposal.parent_certificate,
+                                                        proposal.header.section_root,
+                                                        proposal.header.batch_root,
+                                                        validators.hash());
+        }
+
+        bool verify_proposal(const Proposal&         proposal,
+                             const ValidatorSetView& validators,
+                             const EpochBootstrapV1* bootstrap) {
+            if (proposal.header.protocol_version != ProtocolVersion
+                || proposal.header.network_id != validators.document().network_id
+                || proposal.header.epoch != validators.document().epoch || proposal.header.height == 0
+                || proposal.header.validator_set_hash != validators.hash()
+                || proposal.header.parent_certificate_hash != hash_certificate(proposal.parent_certificate)
+                || proposal.header.height != proposal.parent_certificate.height + 1
+                || proposal.header.section_root.empty() || proposal.header.transaction_root.empty()
+                || proposal.batch.first_section > proposal.batch.last_section
+                || proposal.batch.last_section != proposal.header.dag_section
+                || proposal.batch.transaction_root != proposal.header.transaction_root
+                || proposal.batch.transaction_root != calculate_transaction_root(proposal.batch.transaction_hashes)
+                || proposal.header.batch_root != hash_batch_manifest(proposal.batch)
+                || proposal.batch.data_root.empty() || proposal.batch.payload_bytes == 0
+                || proposal.header.state_commitment != state_commitment(proposal, validators)
+                || !verify_certificate(proposal.parent_certificate, validators, bootstrap)) {
+                return false;
+            }
+            if ((proposal.header.round == 0 && proposal.timeout_certificate.has_value())
+                || (proposal.header.round != 0
+                    && (!proposal.timeout_certificate.has_value()
+                        || !verify_timeout_certificate(proposal.timeout_certificate.value(), validators, bootstrap)
+                        || proposal.timeout_certificate.value().height != proposal.header.height
+                        || proposal.timeout_certificate.value().round + 1 != proposal.header.round
+                        || hash_certificate(proposal.timeout_certificate.value().highest_certificate)
+                               != hash_certificate(proposal.parent_certificate)))) {
+                return false;
+            }
+            if (proposal.parent_certificate.phase == Phase::Genesis) {
+                if (bootstrap != nullptr
+                    && (proposal.batch.first_section != bootstrap->first_dag_section
+                        || proposal.batch.previous_section_root != bootstrap->previous_section_root)) {
+                    return false;
+                }
+                if (bootstrap == nullptr && proposal.batch.first_section == 0
+                    && !proposal.batch.previous_section_root.empty()) {
+                    return false;
+                }
+            }
+            const auto* proposer = validators.find(proposal.proposer_id);
+            return proposer != nullptr && active_at(*proposer, proposal.header.height)
+                   && validators.leader(proposal.header.height, proposal.header.round).validator_id
+                          == proposal.proposer_id
+                   && verify_payload(proposer->consensus_public_key,
+                                     proposal_signing_payload(proposal),
+                                     proposal.signature);
+        }
+
+        bool extends_batch(const Proposal& parent, const Proposal& child) {
+            return parent.batch.last_section != std::numeric_limits<std::uint64_t>::max()
+                   && parent.batch.last_section + 1 == child.batch.first_section
+                   && parent.header.section_root == child.batch.previous_section_root;
+        }
+
+        bool verify_finality(const FinalityProof&    proof,
+                             const ValidatorSetView& validators,
+                             const EpochBootstrapV1* bootstrap) {
+            const auto& first  = proof.finalized_proposal;
+            const auto& second = proof.child_proposal;
+            const auto& third  = proof.grandchild_proposal;
+            return verify_proposal(first, validators, bootstrap) && verify_proposal(second, validators, bootstrap)
+                   && verify_proposal(third, validators, bootstrap)
+                   && first.header.height + 1 == second.header.height
+                   && second.header.height + 1 == third.header.height
+                   && second.parent_certificate.height == first.header.height
+                   && third.parent_certificate.height == second.header.height
+                   && proof.decision_certificate.height == third.header.height
+                   && second.parent_certificate.header_hash == hash_header(first.header)
+                   && third.parent_certificate.header_hash == hash_header(second.header)
+                   && proof.decision_certificate.header_hash == hash_header(third.header)
+                   && extends_batch(first, second) && extends_batch(second, third)
+                   && verify_certificate(second.parent_certificate, validators, bootstrap)
+                   && verify_certificate(third.parent_certificate, validators, bootstrap)
+                   && verify_certificate(proof.decision_certificate, validators, bootstrap);
+        }
+    } // namespace
+
+    LightClientVerifier::LightClientVerifier(ValidatorSetView                trusted_set,
+                                             std::optional<EpochBootstrapV1> bootstrap)
+        : active_(std::move(trusted_set))
+        , active_bootstrap_(std::move(bootstrap))
+        , trusted_epoch_(active_.document().epoch) {
+    }
+
+    std::expected<LightClientVerifier, ConsensusError> LightClientVerifier::create(
+        ValidatorSet                    trusted_set,
+        std::optional<EpochBootstrapV1> bootstrap) {
+        auto validators = ValidatorSetView::create(std::move(trusted_set));
+        if (!validators.has_value()) {
+            return std::unexpected(validators.error());
+        }
+        if (bootstrap.has_value() && !verify_epoch_bootstrap(bootstrap.value(), validators.value().document())) {
+            return std::unexpected(ConsensusError::InvalidEpoch);
+        }
+        return LightClientVerifier(std::move(validators.value()), std::move(bootstrap));
+    }
+
+    std::expected<LightClientVerifier, ConsensusError> LightClientVerifier::restore(LightClientStateV1 state) {
+        if (state.protocol_version != ProtocolVersion || state.network_id != state.active_validators.network_id
+            || state.trusted_epoch != state.active_validators.epoch
+            || (state.trusted_height == 0) != state.trusted_header_hash.empty()) {
+            return std::unexpected(ConsensusError::InvalidProof);
+        }
+        auto verifier = create(std::move(state.active_validators), std::move(state.active_bootstrap));
+        if (!verifier.has_value()) {
+            return std::unexpected(verifier.error());
+        }
+        if (state.pending_epoch.has_value() != state.pending_policy.has_value()) {
+            return std::unexpected(ConsensusError::InvalidEpoch);
+        }
+        if (state.pending_epoch.has_value()) {
+            const auto& transition = state.pending_epoch.value();
+            const auto  scheduled  = verifier.value().schedule_epoch(transition.change,
+                                                                   transition.next_validators,
+                                                                   state.pending_policy.value(),
+                                                                   transition.proof,
+                                                                   state.pending_minimum_sequence);
+            if (!scheduled.has_value() || !verifier.value().pending_bootstrap_.has_value()
+                || hash_epoch_bootstrap(verifier.value().pending_bootstrap_.value())
+                       != hash_epoch_bootstrap(transition.bootstrap)) {
+                return std::unexpected(ConsensusError::InvalidEpoch);
+            }
+        }
+        verifier.value().trusted_epoch_       = state.trusted_epoch;
+        verifier.value().trusted_height_      = state.trusted_height;
+        verifier.value().trusted_header_hash_ = std::move(state.trusted_header_hash);
+        return verifier;
+    }
+
+    std::expected<LightClientVerifier, ConsensusError> LightClientVerifier::load(
+        const std::filesystem::path& path) {
+        const auto bytes = FileIo::read_all(path);
+        if (!bytes.has_value()) {
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        auto state = MessagePack::deserialize<LightClientStateV1>(bytes.value());
+        if (!state.has_value()) {
+            return std::unexpected(ConsensusError::StorageFailure);
+        }
+        return restore(std::move(state.value()));
+    }
+
+    bool LightClientVerifier::verify_finality_proof(const FinalityProof& proof) const {
+        const auto* validators =
+            validators_for(proof.finalized_proposal.header.epoch, proof.finalized_proposal.header.height);
+        return validators != nullptr
+               && verify_finality(proof, *validators, bootstrap_for(proof.finalized_proposal.header.epoch));
+    }
+
+    std::expected<void, ConsensusError> LightClientVerifier::advance(const FinalityProof& proof) {
+        if (!verify_finality_proof(proof)) {
+            return std::unexpected(ConsensusError::InvalidProof);
+        }
+        const auto height      = proof.finalized_proposal.header.height;
+        const auto header_hash = hash_header(proof.finalized_proposal.header);
+        if (height < trusted_height_
+            || (height == trusted_height_ && !trusted_header_hash_.empty()
+                && trusted_header_hash_ != header_hash)) {
+            return std::unexpected(ConsensusError::InvalidHeight);
+        }
+        if (height == trusted_height_ && trusted_header_hash_ == header_hash) {
+            return {};
+        }
+        if (pending_.has_value() && pending_change_.has_value()
+            && proof.finalized_proposal.header.epoch == pending_.value().document().epoch
+            && proof.finalized_proposal.header.height >= pending_change_.value().activation_height) {
+            active_           = std::move(pending_.value());
+            active_bootstrap_ = std::move(pending_bootstrap_);
+            pending_.reset();
+            pending_change_.reset();
+            pending_bootstrap_.reset();
+            pending_transition_.reset();
+            pending_policy_.reset();
+            pending_minimum_sequence_ = 0;
+        }
+        trusted_epoch_       = proof.finalized_proposal.header.epoch;
+        trusted_height_      = height;
+        trusted_header_hash_ = header_hash;
+        return {};
+    }
+
+    bool LightClientVerifier::verify_transaction_proof(const TransactionInclusionProofV1& proof) const {
+        const auto* validators = validators_for(proof.epoch, proof.height);
+        const auto& proposal   = proof.finality_proof.finalized_proposal;
+        return validators != nullptr && proof.protocol_version == ProtocolVersion
+               && proof.network_id == validators->document().network_id
+               && proof.epoch == validators->document().epoch && proof.height == proposal.header.height
+               && !proof.transaction_hash.empty()
+               && verify_finality(proof.finality_proof, *validators, bootstrap_for(proof.epoch))
+               && proposal.header.transaction_root == proposal.batch.transaction_root
+               && verify_merkle_proof(proof.transaction_hash, proof.merkle_proof, proposal.batch.transaction_root);
+    }
+
+    std::expected<void, ConsensusError> LightClientVerifier::schedule_epoch(
+        const EpochChangeV1&               change,
+        ValidatorSet                       next_set,
+        const MultisigPolicy&              policy,
+        const TransactionInclusionProofV1& proof,
+        std::uint64_t                      minimum_sequence) {
+        if (pending_.has_value() || change.current_epoch != active_.document().epoch
+            || change.current_validator_set_hash != active_.hash()
+            || proof.transaction_hash != epoch_change_action_hash(change)
+            || proof.height >= change.activation_height
+            || (active_bootstrap_.has_value() && proof.height < active_bootstrap_.value().activation_height)
+            || !verify_transaction_proof(proof)) {
+            return std::unexpected(ConsensusError::InvalidEpoch);
+        }
+        auto next = ValidatorSetView::create_epoch_transition(std::move(next_set),
+                                                              change,
+                                                              policy,
+                                                              proof.height,
+                                                              minimum_sequence);
+        if (!next.has_value()) {
+            return std::unexpected(next.error());
+        }
+        const auto bootstrap = make_epoch_bootstrap(change, next.value().document(), proof);
+        if (!bootstrap.has_value()) {
+            return std::unexpected(bootstrap.error());
+        }
+        pending_            = std::move(next.value());
+        pending_change_     = change;
+        pending_bootstrap_  = bootstrap.value();
+        pending_transition_ = EpochTransitionV1 {
+            .change          = change,
+            .next_validators = pending_.value().document(),
+            .proof           = proof,
+            .bootstrap       = bootstrap.value(),
+        };
+        pending_policy_           = policy;
+        pending_minimum_sequence_ = minimum_sequence;
+        return {};
+    }
+
+    const ValidatorSetView& LightClientVerifier::active_validators() const noexcept {
+        return active_;
+    }
+
+    const std::optional<ValidatorSetView>& LightClientVerifier::pending_validators() const noexcept {
+        return pending_;
+    }
+
+    LightClientStateV1 LightClientVerifier::snapshot() const {
+        return LightClientStateV1 {
+            .network_id               = active_.document().network_id,
+            .active_validators        = active_.document(),
+            .active_bootstrap         = active_bootstrap_,
+            .pending_epoch            = pending_transition_,
+            .pending_policy           = pending_policy_,
+            .pending_minimum_sequence = pending_minimum_sequence_,
+            .trusted_epoch            = trusted_epoch_,
+            .trusted_height           = trusted_height_,
+            .trusted_header_hash      = trusted_header_hash_,
+        };
+    }
+
+    std::expected<void, ConsensusError> LightClientVerifier::save(const std::filesystem::path& path) const {
+        const auto written = FileIo::write_atomic(path, MessagePack::serialize(snapshot()));
+        return written.has_value() ? std::expected<void, ConsensusError> {}
+                                   : std::unexpected(ConsensusError::StorageFailure);
+    }
+
+    std::uint64_t LightClientVerifier::trusted_height() const noexcept {
+        return trusted_height_;
+    }
+
+    const ValidatorSetView* LightClientVerifier::validators_for(std::uint64_t epoch,
+                                                                std::uint64_t height) const noexcept {
+        if (pending_.has_value() && pending_change_.has_value() && epoch == pending_.value().document().epoch
+            && height >= pending_change_.value().activation_height) {
+            return &pending_.value();
+        }
+        if (epoch == active_.document().epoch
+            && (!active_bootstrap_.has_value() || height >= active_bootstrap_.value().activation_height)
+            && (!pending_change_.has_value() || height < pending_change_.value().activation_height)) {
+            return &active_;
+        }
+        return nullptr;
+    }
+
+    const EpochBootstrapV1* LightClientVerifier::bootstrap_for(std::uint64_t epoch) const noexcept {
+        if (pending_.has_value() && pending_bootstrap_.has_value() && pending_.value().document().epoch == epoch) {
+            return &pending_bootstrap_.value();
+        }
+        return active_bootstrap_.has_value() && active_.document().epoch == epoch ? &active_bootstrap_.value()
+                                                                                  : nullptr;
+    }
+
+} // namespace ExtraChain::Consensus

--- a/sources/consensus/shadow_consensus.cpp
+++ b/sources/consensus/shadow_consensus.cpp
@@ -10,15 +10,22 @@
 
 #include "consensus/shadow_consensus.h"
 
+#include <fmt/format.h>
+
+#include "consensus/light_client.h"
 #include "utils/file_io.h"
 #include "utils/serialization.h"
 
 namespace ExtraChain::Consensus {
     namespace {
-        constexpr std::string_view ValidatorSetFile  = "validator-set.msgpack";
-        constexpr std::string_view IdentityFile      = "identity.msgpack";
-        constexpr std::string_view SafetyFile        = "safety.sqlite";
-        constexpr std::string_view ConfigurationFile = "shadow-config.msgpack";
+        constexpr std::string_view ValidatorSetFile       = "validator-set.msgpack";
+        constexpr std::string_view IdentityFile           = "identity.msgpack";
+        constexpr std::string_view SafetyFile             = "safety.sqlite";
+        constexpr std::string_view ConfigurationFile      = "shadow-config.msgpack";
+        constexpr std::string_view GovernancePolicyFile   = "governance-policy.msgpack";
+        constexpr std::string_view ActivationManifestFile = "activation-manifest.msgpack";
+        constexpr std::string_view EpochHistoryFile       = "epoch-history.msgpack";
+        constexpr std::string_view PendingEpochFile       = "pending-epoch.msgpack";
 
         template <typename T>
         std::expected<T, ConsensusError> read_document(const std::filesystem::path& path) {
@@ -41,11 +48,64 @@ namespace ExtraChain::Consensus {
             }
             return {};
         }
+
+        std::filesystem::path epoch_identity_path(const std::filesystem::path& directory, std::uint64_t epoch) {
+            return directory / fmt::format("identity-epoch-{}.msgpack", epoch);
+        }
+
+        std::filesystem::path epoch_safety_path(const std::filesystem::path& directory, std::uint64_t epoch) {
+            return directory / fmt::format("safety-epoch-{}.sqlite", epoch);
+        }
+
+        std::expected<std::optional<ValidatorIdentity>, ConsensusError> read_identity(
+            const std::filesystem::path& path,
+            const ValidatorSetView&      validators) {
+            if (!std::filesystem::exists(path)) {
+                return std::optional<ValidatorIdentity> {};
+            }
+#ifndef _WIN32
+            std::error_code permission_error;
+            const auto      permissions = std::filesystem::status(path, permission_error).permissions();
+            constexpr auto  public_permissions =
+                std::filesystem::perms::group_all | std::filesystem::perms::others_all;
+            if (permission_error || (permissions & public_permissions) != std::filesystem::perms::none) {
+                return std::unexpected(ConsensusError::StorageFailure);
+            }
+#endif
+            const auto document = read_document<IdentityDocument>(path);
+            if (!document.has_value() || document.value().protocol_version != ProtocolVersion
+                || document.value().validator_id != validator_id_for(document.value().key.public_key())) {
+                return std::unexpected(ConsensusError::InvalidValidator);
+            }
+            const auto* validator = validators.find(document.value().validator_id);
+            if (validator == nullptr) {
+                return std::optional<ValidatorIdentity> {};
+            }
+            return std::optional<ValidatorIdentity>(ValidatorIdentity {
+                .validator_id = document.value().validator_id,
+                .key          = document.value().key,
+            });
+        }
     } // namespace
 
-    ShadowConsensus::ShadowConsensus(std::unique_ptr<ConsensusEngine> engine, ShadowConfiguration configuration)
+    ShadowConsensus::ShadowConsensus(std::filesystem::path              directory,
+                                     std::unique_ptr<ConsensusEngine>   engine,
+                                     ShadowConfiguration                configuration,
+                                     std::optional<MultisigPolicy>      governance_policy,
+                                     std::vector<EpochTransitionV1>     epoch_history,
+                                     std::optional<EpochTransitionV1>   pending_epoch,
+                                     std::optional<EpochBootstrapV1>    active_bootstrap,
+                                     std::uint64_t                      minimum_governance_sequence,
+                                     ConsensusEngine::ProposalValidator proposal_validator)
         : engine_(std::move(engine))
-        , configuration_(configuration) {
+        , configuration_(configuration)
+        , directory_(std::move(directory))
+        , governance_policy_(std::move(governance_policy))
+        , epoch_history_(std::move(epoch_history))
+        , pending_epoch_(std::move(pending_epoch))
+        , active_bootstrap_(std::move(active_bootstrap))
+        , minimum_governance_sequence_(minimum_governance_sequence)
+        , proposal_validator_(std::move(proposal_validator)) {
     }
 
     std::expected<std::unique_ptr<ShadowConsensus>, ConsensusError> ShadowConsensus::load(
@@ -59,33 +119,9 @@ namespace ExtraChain::Consensus {
         if (validator_document.value().network_id != network_id) {
             return std::unexpected(ConsensusError::InvalidNetwork);
         }
-        auto validators = ValidatorSetView::create(validator_document.value());
-        if (!validators.has_value()) {
-            return std::unexpected(validators.error());
-        }
-
-        std::optional<ValidatorIdentity> identity;
-        if (std::filesystem::exists(directory / IdentityFile)) {
-#ifndef _WIN32
-            std::error_code permission_error;
-            const auto      permissions =
-                std::filesystem::status(directory / IdentityFile, permission_error).permissions();
-            constexpr auto public_permissions =
-                std::filesystem::perms::group_all | std::filesystem::perms::others_all;
-            if (permission_error || (permissions & public_permissions) != std::filesystem::perms::none) {
-                return std::unexpected(ConsensusError::StorageFailure);
-            }
-#endif
-            const auto document = read_document<IdentityDocument>(directory / IdentityFile);
-            if (!document.has_value()) {
-                return std::unexpected(document.error());
-            }
-            if (document.value().protocol_version != ProtocolVersion
-                || document.value().validator_id != validator_id_for(document.value().key.public_key())) {
-                return std::unexpected(ConsensusError::InvalidValidator);
-            }
-            identity =
-                ValidatorIdentity { .validator_id = document.value().validator_id, .key = document.value().key };
+        auto initial_validators = ValidatorSetView::create(validator_document.value());
+        if (!initial_validators.has_value()) {
+            return std::unexpected(initial_validators.error());
         }
 
         ShadowConfiguration configuration;
@@ -108,15 +144,139 @@ namespace ExtraChain::Consensus {
             configuration = loaded_configuration.value();
         }
 
+        std::optional<MultisigPolicy> governance_policy;
+        std::uint64_t                 minimum_sequence = 1;
+        if (configuration.mode == ShadowMode::Finality) {
+            const auto policy   = read_document<MultisigPolicy>(directory / GovernancePolicyFile);
+            const auto manifest = read_document<ActivationManifestV1>(directory / ActivationManifestFile);
+            if (initial_validators.value().active().size() != ShadowCommitteeSize || !policy.has_value()
+                || !manifest.has_value() || manifest.value().activation_height == 0
+                || manifest.value().authorization.sequence == std::numeric_limits<std::uint64_t>::max()
+                || !verify_multisig_policy(policy.value())
+                || !verify_activation_manifest(manifest.value(),
+                                               policy.value(),
+                                               manifest.value().activation_height - 1,
+                                               1)
+                || manifest.value().network_id != network_id
+                || manifest.value().activation_height != configuration.activation_height
+                || manifest.value().activation_dag_section != configuration.activation_dag_section
+                || manifest.value().validator_set_hash != hash_validator_set(validator_document.value())) {
+                return std::unexpected(ConsensusError::InvalidGovernance);
+            }
+            governance_policy = policy.value();
+            minimum_sequence  = manifest.value().authorization.sequence + 1;
+        }
+
+        std::vector<EpochTransitionV1> epoch_history;
+        if (std::filesystem::exists(directory / EpochHistoryFile)) {
+            const auto loaded = read_document<std::vector<EpochTransitionV1>>(directory / EpochHistoryFile);
+            if (!loaded.has_value() || !governance_policy.has_value()) {
+                return std::unexpected(ConsensusError::InvalidEpoch);
+            }
+            epoch_history = loaded.value();
+        }
+
+        ValidatorSet                    active_document = validator_document.value();
+        std::optional<EpochBootstrapV1> active_bootstrap;
+        for (const auto& transition : epoch_history) {
+            auto verifier = LightClientVerifier::create(active_document, active_bootstrap);
+            if (!verifier.has_value() || transition.protocol_version != ProtocolVersion
+                || transition.change.authorization.sequence == std::numeric_limits<std::uint64_t>::max()
+                || !verifier.value()
+                        .schedule_epoch(transition.change,
+                                        transition.next_validators,
+                                        governance_policy.value(),
+                                        transition.proof,
+                                        minimum_sequence)
+                        .has_value()) {
+                return std::unexpected(ConsensusError::InvalidEpoch);
+            }
+            const auto expected =
+                make_epoch_bootstrap(transition.change, transition.next_validators, transition.proof);
+            if (!expected.has_value()
+                || hash_epoch_bootstrap(expected.value()) != hash_epoch_bootstrap(transition.bootstrap)) {
+                return std::unexpected(ConsensusError::InvalidEpoch);
+            }
+            minimum_sequence = transition.change.authorization.sequence + 1;
+            active_document  = transition.next_validators;
+            active_bootstrap = transition.bootstrap;
+        }
+
+        auto validators = ValidatorSetView::create(active_document);
+        if (!validators.has_value()) {
+            return std::unexpected(validators.error());
+        }
+
+        std::optional<EpochTransitionV1> pending_epoch;
+        if (std::filesystem::exists(directory / PendingEpochFile)) {
+            const auto loaded = read_document<EpochTransitionV1>(directory / PendingEpochFile);
+            if (!loaded.has_value()) {
+                return std::unexpected(ConsensusError::InvalidEpoch);
+            }
+            const bool already_active = !epoch_history.empty()
+                                        && hash_epoch_bootstrap(epoch_history.back().bootstrap)
+                                               == hash_epoch_bootstrap(loaded.value().bootstrap);
+            if (already_active) {
+                std::error_code remove_error;
+                std::filesystem::remove(directory / PendingEpochFile, remove_error);
+                if (remove_error) {
+                    return std::unexpected(ConsensusError::StorageFailure);
+                }
+            } else {
+                auto verifier = LightClientVerifier::create(active_document, active_bootstrap);
+                if (!governance_policy.has_value() || !verifier.has_value()
+                    || loaded.value().change.authorization.sequence == std::numeric_limits<std::uint64_t>::max()
+                    || !verifier.value()
+                            .schedule_epoch(loaded.value().change,
+                                            loaded.value().next_validators,
+                                            governance_policy.value(),
+                                            loaded.value().proof,
+                                            minimum_sequence)
+                            .has_value()) {
+                    return std::unexpected(ConsensusError::InvalidEpoch);
+                }
+                const auto expected = make_epoch_bootstrap(loaded.value().change,
+                                                           loaded.value().next_validators,
+                                                           loaded.value().proof);
+                if (!expected.has_value()
+                    || hash_epoch_bootstrap(expected.value()) != hash_epoch_bootstrap(loaded.value().bootstrap)) {
+                    return std::unexpected(ConsensusError::InvalidEpoch);
+                }
+                pending_epoch = loaded.value();
+            }
+        }
+
+        auto       identity_path = directory / IdentityFile;
+        const auto epoch_path    = epoch_identity_path(directory, validators.value().document().epoch);
+        if (active_bootstrap.has_value() && std::filesystem::exists(epoch_path)) {
+            identity_path = epoch_path;
+        }
+        auto identity = read_identity(identity_path, validators.value());
+        if (!identity.has_value()) {
+            return std::unexpected(identity.error());
+        }
+
+        const auto safety_path = active_bootstrap.has_value()
+                                     ? epoch_safety_path(directory, validators.value().document().epoch)
+                                     : directory / SafetyFile;
         auto       engine      = std::make_unique<ConsensusEngine>(std::move(validators.value()),
-                                                        std::move(identity),
-                                                        std::make_unique<SafetyStore>(directory / SafetyFile),
-                                                        std::move(proposal_validator));
+                                                        std::move(identity.value()),
+                                                        std::make_unique<SafetyStore>(safety_path),
+                                                        proposal_validator,
+                                                        active_bootstrap);
         const auto initialized = engine->initialize();
         if (!initialized.has_value()) {
             return std::unexpected(initialized.error());
         }
-        return std::unique_ptr<ShadowConsensus>(new ShadowConsensus(std::move(engine), configuration));
+        return std::unique_ptr<ShadowConsensus>(new ShadowConsensus(directory,
+                                                                    std::move(engine),
+                                                                    configuration,
+                                                                    std::move(governance_policy),
+                                                                    std::move(epoch_history),
+                                                                    std::move(pending_epoch),
+                                                                    std::move(active_bootstrap),
+                                                                    minimum_sequence,
+                                                                    std::move(proposal_validator)));
     }
 
     std::expected<void, ConsensusError> ShadowConsensus::write_identity(const std::filesystem::path& directory,
@@ -137,6 +297,36 @@ namespace ExtraChain::Consensus {
         }
 #ifndef _WIN32
         std::filesystem::permissions(identity_path,
+                                     std::filesystem::perms::owner_read | std::filesystem::perms::owner_write,
+                                     std::filesystem::perm_options::replace,
+                                     error);
+        if (error) {
+            return std::unexpected(ConsensusError::StorageFailure);
+        }
+#endif
+        return {};
+    }
+
+    std::expected<void, ConsensusError> ShadowConsensus::write_epoch_identity(
+        const std::filesystem::path& directory,
+        std::uint64_t                epoch,
+        const IdentityDocument&      identity) {
+        if (epoch == 0 || identity.protocol_version != ProtocolVersion || identity.key.empty()
+            || identity.validator_id != validator_id_for(identity.key.public_key())) {
+            return std::unexpected(ConsensusError::InvalidValidator);
+        }
+        std::error_code error;
+        std::filesystem::create_directories(directory, error);
+        if (error) {
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        const auto path    = epoch_identity_path(directory, epoch);
+        const auto written = write_document(path, identity);
+        if (!written.has_value()) {
+            return written;
+        }
+#ifndef _WIN32
+        std::filesystem::permissions(path,
                                      std::filesystem::perms::owner_read | std::filesystem::perms::owner_write,
                                      std::filesystem::perm_options::replace,
                                      error);
@@ -180,6 +370,37 @@ namespace ExtraChain::Consensus {
             return std::unexpected(ConsensusError::StorageUnavailable);
         }
         return write_document(directory / ConfigurationFile, configuration);
+    }
+
+    std::expected<void, ConsensusError> ShadowConsensus::write_governance_policy(
+        const std::filesystem::path& directory,
+        const MultisigPolicy&        policy) {
+        if (!verify_multisig_policy(policy) || policy.public_keys.size() != GovernanceSignerCount
+            || policy.threshold != GovernanceThreshold) {
+            return std::unexpected(ConsensusError::InvalidGovernance);
+        }
+        std::error_code error;
+        std::filesystem::create_directories(directory, error);
+        if (error) {
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        return write_document(directory / GovernancePolicyFile, policy);
+    }
+
+    std::expected<void, ConsensusError> ShadowConsensus::write_activation_manifest(
+        const std::filesystem::path& directory,
+        const ActivationManifestV1&  manifest,
+        const MultisigPolicy&        policy) {
+        if (manifest.activation_height == 0
+            || !verify_activation_manifest(manifest, policy, manifest.activation_height - 1, 1)) {
+            return std::unexpected(ConsensusError::InvalidGovernance);
+        }
+        std::error_code error;
+        std::filesystem::create_directories(directory, error);
+        if (error) {
+            return std::unexpected(ConsensusError::StorageUnavailable);
+        }
+        return write_document(directory / ActivationManifestFile, manifest);
     }
 
     std::expected<std::optional<Proposal>, ConsensusError> ShadowConsensus::make_checkpoint_proposal(
@@ -252,6 +473,126 @@ namespace ExtraChain::Consensus {
         return engine_->accept_certificate(certificate);
     }
 
+    std::expected<void, ConsensusError> ShadowConsensus::schedule_epoch(const EpochChangeV1& change,
+                                                                        ValidatorSet         next_validators,
+                                                                        const TransactionInclusionProofV1& proof) {
+        if (configuration_.mode != ShadowMode::Finality || !governance_policy_.has_value()
+            || pending_epoch_.has_value() || change.current_epoch != engine_->validators().document().epoch
+            || change.current_validator_set_hash != engine_->validators().hash()
+            || !engine_->verify_transaction_inclusion_proof(proof)) {
+            return std::unexpected(ConsensusError::InvalidEpoch);
+        }
+        const auto next      = ValidatorSetView::create_epoch_transition(next_validators,
+                                                                    change,
+                                                                    governance_policy_.value(),
+                                                                    proof.height,
+                                                                    minimum_governance_sequence_);
+        const auto bootstrap = make_epoch_bootstrap(change, next_validators, proof);
+        if (!next.has_value() || !bootstrap.has_value()) {
+            return std::unexpected(ConsensusError::InvalidEpoch);
+        }
+        const auto& highest = engine_->safety_state().highest_certificate;
+        if (!highest.has_value() || highest.value().height + 1 > bootstrap.value().activation_height) {
+            return std::unexpected(ConsensusError::InvalidHeight);
+        }
+        EpochTransitionV1 transition {
+            .change          = change,
+            .next_validators = std::move(next_validators),
+            .proof           = proof,
+            .bootstrap       = bootstrap.value(),
+        };
+        const auto written = write_document(directory_ / PendingEpochFile, transition);
+        if (!written.has_value()) {
+            return std::unexpected(written.error());
+        }
+        pending_epoch_ = std::move(transition);
+        return {};
+    }
+
+    std::expected<void, ConsensusError> ShadowConsensus::validate_epoch_request(
+        const EpochChangeRequestV1& request,
+        std::uint64_t               proposal_height) const {
+        if (configuration_.mode != ShadowMode::Finality || !governance_policy_.has_value()
+            || pending_epoch_.has_value() || request.protocol_version != ProtocolVersion
+            || request.change.authorization.sequence == std::numeric_limits<std::uint64_t>::max()
+            || request.change.current_epoch != engine_->validators().document().epoch
+            || request.change.current_validator_set_hash != engine_->validators().hash()
+            || request.change.activation_height != proposal_height + 3) {
+            return std::unexpected(ConsensusError::InvalidEpoch);
+        }
+        const auto validators = ValidatorSetView::create_epoch_transition(request.next_validators,
+                                                                          request.change,
+                                                                          governance_policy_.value(),
+                                                                          proposal_height,
+                                                                          minimum_governance_sequence_);
+        return validators.has_value() ? std::expected<void, ConsensusError> {}
+                                      : std::unexpected(validators.error());
+    }
+
+    std::expected<bool, ConsensusError> ShadowConsensus::activate_scheduled_epoch() {
+        if (!pending_epoch_.has_value()) {
+            return false;
+        }
+        const auto& transition = pending_epoch_.value();
+        const auto& highest    = engine_->safety_state().highest_certificate;
+        if (!highest.has_value() || highest.value().height + 1 < transition.bootstrap.activation_height) {
+            return false;
+        }
+        if (highest.value().height + 1 != transition.bootstrap.activation_height
+            || hash_certificate(highest.value()) != transition.bootstrap.previous_decision_certificate_hash
+            || !governance_policy_.has_value()) {
+            return std::unexpected(ConsensusError::InvalidEpoch);
+        }
+        auto validators = ValidatorSetView::create_epoch_transition(transition.next_validators,
+                                                                    transition.change,
+                                                                    governance_policy_.value(),
+                                                                    transition.proof.height,
+                                                                    minimum_governance_sequence_);
+        if (!validators.has_value()) {
+            return std::unexpected(validators.error());
+        }
+
+        auto identity_path = epoch_identity_path(directory_, transition.next_validators.epoch);
+        if (!std::filesystem::exists(identity_path)) {
+            identity_path = directory_ / IdentityFile;
+        }
+        auto identity = read_identity(identity_path, validators.value());
+        if (!identity.has_value()) {
+            return std::unexpected(identity.error());
+        }
+
+        auto next_engine =
+            std::make_unique<ConsensusEngine>(std::move(validators.value()),
+                                              std::move(identity.value()),
+                                              std::make_unique<SafetyStore>(
+                                                  epoch_safety_path(directory_, transition.next_validators.epoch)),
+                                              proposal_validator_,
+                                              transition.bootstrap);
+        const auto initialized = next_engine->initialize();
+        if (!initialized.has_value()) {
+            return std::unexpected(initialized.error());
+        }
+
+        auto next_history = epoch_history_;
+        next_history.push_back(transition);
+        const auto history_written = write_document(directory_ / EpochHistoryFile, next_history);
+        if (!history_written.has_value()) {
+            return std::unexpected(history_written.error());
+        }
+
+        std::error_code remove_error;
+        std::filesystem::remove(directory_ / PendingEpochFile, remove_error);
+        if (remove_error) {
+            return std::unexpected(ConsensusError::StorageFailure);
+        }
+        engine_                      = std::move(next_engine);
+        epoch_history_               = std::move(next_history);
+        active_bootstrap_            = transition.bootstrap;
+        minimum_governance_sequence_ = transition.change.authorization.sequence + 1;
+        pending_epoch_.reset();
+        return true;
+    }
+
     const ConsensusEngine& ShadowConsensus::engine() const noexcept {
         return *engine_;
     }
@@ -262,6 +603,10 @@ namespace ExtraChain::Consensus {
 
     const ShadowConfiguration& ShadowConsensus::configuration() const noexcept {
         return configuration_;
+    }
+
+    const std::optional<EpochTransitionV1>& ShadowConsensus::pending_epoch() const noexcept {
+        return pending_epoch_;
     }
 
     bool ShadowConsensus::peer_matches_validator(std::string_view validator_id,

--- a/sources/consensus/validator_set.cpp
+++ b/sources/consensus/validator_set.cpp
@@ -12,19 +12,22 @@
 
 #include <algorithm>
 #include <set>
+#include <tuple>
 
 #include "core/byte_array.h"
 #include "utils/exc_utils.h"
 #include "utils/exc_utils_base64.h"
+#include "utils/serialization.h"
 
 namespace ExtraChain::Consensus {
     namespace {
-        std::optional<ActorId> actor_id_for(std::string_view encoded_public_key) {
+        constexpr std::string_view GenesisDomain = "EXC_CONSENSUS_GENESIS_V1";
+        std::optional<ActorId>     actor_id_for(std::string_view encoded_public_key) {
             const auto decoded = ByteArray::fromBase64(encoded_public_key);
             if (!decoded.has_value() || decoded.value().size() != crypto_sign_PUBLICKEYBYTES) {
                 return std::nullopt;
             }
-            const auto hash     = Utils::calculate_hash(decoded.value().toString(), Utils::HashAlgorithm::Blake3);
+            const auto hash = Utils::calculate_hash(decoded.value().toString(), Utils::HashAlgorithm::Blake3);
             const auto actor_id = ActorId::create(hash.substr(0, ActorId::SIZE));
             return actor_id.has_value() ? std::optional<ActorId>(actor_id.value()) : std::nullopt;
         }
@@ -46,6 +49,58 @@ namespace ExtraChain::Consensus {
                    && verify_payload(record.consensus_public_key,
                                      validator_binding_payload(record),
                                      record.consensus_signature);
+        }
+
+        std::expected<std::pair<std::vector<ValidatorRecord>, std::string>, ConsensusError> validate_records(
+            ValidatorSet& validators) {
+            std::set<std::string>        validator_ids;
+            std::set<ActorId>            actor_ids;
+            std::set<std::string>        node_identifiers;
+            std::set<std::string>        consensus_keys;
+            std::vector<ValidatorRecord> active;
+            for (const auto& validator : validators.validators) {
+                if (!valid_record(validator, validators.network_id, validators.epoch)
+                    || !validator_ids.insert(validator.validator_id).second
+                    || !consensus_keys.insert(validator.consensus_public_key).second) {
+                    return std::unexpected(ConsensusError::InvalidValidatorSet);
+                }
+                if (validator.status != ValidatorStatus::Active) {
+                    continue;
+                }
+                if (validator.valid_from != 0 || validator.valid_until != 0) {
+                    return std::unexpected(ConsensusError::InvalidValidatorSet);
+                }
+                if (!actor_ids.insert(validator.actor_id).second
+                    || !node_identifiers.insert(validator.node_identifier).second) {
+                    return std::unexpected(ConsensusError::InvalidValidatorSet);
+                }
+                active.push_back(validator);
+            }
+            if (active.size() < 4) {
+                return std::unexpected(ConsensusError::InvalidValidatorSet);
+            }
+            std::ranges::sort(active, {}, &ValidatorRecord::validator_id);
+            std::ranges::sort(validators.validators, {}, &ValidatorRecord::validator_id);
+            return std::pair { std::move(active), hash_validator_set(validators) };
+        }
+
+        bool operators_match(const std::vector<OperatorAttestation>& operators,
+                             const std::vector<ValidatorRecord>&     active) {
+            if (operators.size() != active.size()) {
+                return false;
+            }
+            std::set<std::string> operator_ids;
+            for (const auto& validator : active) {
+                const auto found = std::ranges::find_if(operators, [&](const auto& item) {
+                    return item.actor_id == validator.actor_id && item.node_identifier == validator.node_identifier
+                           && item.consensus_public_key == validator.consensus_public_key;
+                });
+                if (found == operators.end() || found->operator_id_hash.empty() || found->document_hash.empty()
+                    || found->policy_version == 0 || !operator_ids.insert(found->operator_id_hash).second) {
+                    return false;
+                }
+            }
+            return true;
         }
     } // namespace
 
@@ -71,37 +126,61 @@ namespace ExtraChain::Consensus {
             return std::unexpected(ConsensusError::InvalidSignature);
         }
 
-        std::set<std::string>        validator_ids;
-        std::set<ActorId>            actor_ids;
-        std::set<std::string>        node_identifiers;
-        std::set<std::string>        consensus_keys;
-        std::vector<ValidatorRecord> active;
-        for (const auto& validator : validators.validators) {
-            if (!valid_record(validator, validators.network_id, validators.epoch)
-                || !validator_ids.insert(validator.validator_id).second
-                || !consensus_keys.insert(validator.consensus_public_key).second) {
-                return std::unexpected(ConsensusError::InvalidValidatorSet);
-            }
-            if (validator.status != ValidatorStatus::Active) {
-                continue;
-            }
-            if (validator.valid_from != 0 || validator.valid_until != 0) {
-                return std::unexpected(ConsensusError::InvalidValidatorSet);
-            }
-            if (!actor_ids.insert(validator.actor_id).second
-                || !node_identifiers.insert(validator.node_identifier).second) {
-                return std::unexpected(ConsensusError::InvalidValidatorSet);
-            }
-            active.push_back(validator);
+        auto records = validate_records(validators);
+        if (!records.has_value()) {
+            return std::unexpected(records.error());
         }
+        return ValidatorSetView(std::move(validators),
+                                std::move(records.value().first),
+                                std::move(records.value().second));
+    }
 
-        if (active.size() < 4) {
+    std::expected<ValidatorSetView, ConsensusError> ValidatorSetView::create_governed(
+        ValidatorSet                            validators,
+        std::string                             registry_document_hash,
+        const std::vector<OperatorAttestation>& operators,
+        const MultisigPolicy&                   policy,
+        const GovernanceAuthorization&          authorization,
+        std::uint64_t                           minimum_sequence) {
+        if (validators.protocol_version != ProtocolVersion || validators.network_id != policy.network_id
+            || validators.epoch == 0 || registry_document_hash.empty()) {
             return std::unexpected(ConsensusError::InvalidValidatorSet);
         }
-        std::ranges::sort(active, {}, &ValidatorRecord::validator_id);
-        std::ranges::sort(validators.validators, {}, &ValidatorRecord::validator_id);
-        const auto validator_set_hash = hash_validator_set(validators);
-        return ValidatorSetView(std::move(validators), std::move(active), validator_set_hash);
+        auto records = validate_records(validators);
+        if (!records.has_value() || records.value().first.size() != ShadowCommitteeSize
+            || !operators_match(operators, records.value().first)) {
+            return std::unexpected(ConsensusError::InvalidValidatorSet);
+        }
+        if (authorization.action_hash
+                != governed_validator_set_action_hash(validators, registry_document_hash, operators)
+            || !verify_authorization(policy, authorization, minimum_sequence)) {
+            return std::unexpected(ConsensusError::InvalidGovernance);
+        }
+        return ValidatorSetView(std::move(validators),
+                                std::move(records.value().first),
+                                std::move(records.value().second));
+    }
+
+    std::expected<ValidatorSetView, ConsensusError> ValidatorSetView::create_epoch_transition(
+        ValidatorSet          validators,
+        const EpochChangeV1&  change,
+        const MultisigPolicy& policy,
+        std::uint64_t         current_height,
+        std::uint64_t         minimum_sequence) {
+        if (!verify_epoch_change(change, policy, current_height, minimum_sequence)
+            || validators.protocol_version != ProtocolVersion || validators.network_id != change.network_id
+            || validators.epoch != change.activation_epoch
+            || hash_validator_set(validators) != change.next_validator_set_hash) {
+            return std::unexpected(ConsensusError::InvalidValidatorSet);
+        }
+        auto records = validate_records(validators);
+        if (!records.has_value() || records.value().first.size() != ShadowCommitteeSize
+            || !operators_match(change.operators, records.value().first)) {
+            return std::unexpected(ConsensusError::InvalidValidatorSet);
+        }
+        return ValidatorSetView(std::move(validators),
+                                std::move(records.value().first),
+                                std::move(records.value().second));
     }
 
     const ValidatorSet& ValidatorSetView::document() const noexcept {
@@ -197,6 +276,69 @@ namespace ExtraChain::Consensus {
         }
         result.governance_signature = signature.value();
         return result;
+    }
+
+    std::string governed_validator_set_action_hash(const ValidatorSet&                     validators,
+                                                   std::string_view                        registry_document_hash,
+                                                   const std::vector<OperatorAttestation>& operators) {
+        auto canonical_validators = validators;
+        auto canonical_operators  = operators;
+        std::ranges::sort(canonical_validators.validators, {}, &ValidatorRecord::validator_id);
+        std::ranges::sort(canonical_operators, [](const auto& left, const auto& right) {
+            return std::tie(left.operator_id_hash,
+                            left.actor_id,
+                            left.node_identifier,
+                            left.consensus_public_key,
+                            left.document_hash,
+                            left.policy_version)
+                   < std::tie(right.operator_id_hash,
+                              right.actor_id,
+                              right.node_identifier,
+                              right.consensus_public_key,
+                              right.document_hash,
+                              right.policy_version);
+        });
+        return Utils::calculate_hash(std::string("EXC_GOVERNED_VALIDATOR_SET_V2")
+                                         + MessagePack::serialize(
+                                             std::tuple { canonical_validators.protocol_version,
+                                                          canonical_validators.network_id,
+                                                          canonical_validators.epoch,
+                                                          hash_validator_set(canonical_validators),
+                                                          std::string(registry_document_hash),
+                                                          canonical_operators }),
+                                     Utils::HashAlgorithm::Blake3);
+    }
+
+    QuorumCertificate make_genesis_certificate(const ValidatorSetView& validators) {
+        const auto payload =
+            std::string(GenesisDomain) + validators.document().network_id.to_string() + validators.hash();
+        return QuorumCertificate {
+            .protocol_version = ProtocolVersion,
+            .network_id       = validators.document().network_id,
+            .epoch            = validators.document().epoch,
+            .height           = 0,
+            .round            = 0,
+            .phase            = Phase::Genesis,
+            .header_hash      = Utils::calculate_hash(payload, Utils::HashAlgorithm::Blake3),
+            .signer_bitmap    = std::vector<std::uint8_t>((validators.active().size() + 7) / 8, 0),
+        };
+    }
+
+    QuorumCertificate make_epoch_genesis_certificate(const ValidatorSetView& validators,
+                                                     const EpochBootstrapV1& bootstrap) {
+        if (!verify_epoch_bootstrap(bootstrap, validators.document())) {
+            return {};
+        }
+        return QuorumCertificate {
+            .protocol_version = ProtocolVersion,
+            .network_id       = validators.document().network_id,
+            .epoch            = validators.document().epoch,
+            .height           = bootstrap.activation_height - 1,
+            .round            = 0,
+            .phase            = Phase::Genesis,
+            .header_hash      = hash_epoch_bootstrap(bootstrap),
+            .signer_bitmap    = std::vector<std::uint8_t>((validators.active().size() + 7) / 8, 0),
+        };
     }
 
 } // namespace ExtraChain::Consensus

--- a/sources/core/extrachain_node.cpp
+++ b/sources/core/extrachain_node.cpp
@@ -1528,7 +1528,8 @@ namespace ExtraChain::Core {
         }
     }
 
-    TransactionProveError ExtraChainNode::validate_contract_transaction(const Transaction& transaction) {
+    TransactionProveError ExtraChainNode::validate_contract_transaction(const Transaction& transaction,
+                                                                        bool               stage_change) {
         if (!transaction.meta().has_value()) {
             return TransactionProveError::InvalidContractPayload;
         }
@@ -1654,8 +1655,8 @@ namespace ExtraChain::Core {
                 return TransactionProveError::InvalidContractPayload;
             }
             const auto verified = verify_output(change->output);
-            if (verified == TransactionProveError::NoError) {
-                if (!stage_contract_change(transaction.hash(), std::move(*change))) {
+            if (verified == TransactionProveError::NoError && stage_change) {
+                if (!stage_contract_change(transaction.hash(), std::move(change.value()))) {
                     return TransactionProveError::InvalidContractPayload;
                 }
             }
@@ -1705,8 +1706,8 @@ namespace ExtraChain::Core {
                 return TransactionProveError::InvalidContractPayload;
             }
             const auto verified = verify_output(change->output);
-            if (verified == TransactionProveError::NoError) {
-                if (!stage_contract_change(transaction.hash(), std::move(*change))) {
+            if (verified == TransactionProveError::NoError && stage_change) {
+                if (!stage_contract_change(transaction.hash(), std::move(change.value()))) {
                     return TransactionProveError::InvalidContractPayload;
                 }
             }
@@ -1750,8 +1751,8 @@ namespace ExtraChain::Core {
             return TransactionProveError::InvalidContractPayload;
         }
         const auto verified = verify_output(change->output);
-        if (verified == TransactionProveError::NoError) {
-            if (!stage_contract_change(transaction.hash(), std::move(*change))) {
+        if (verified == TransactionProveError::NoError && stage_change) {
+            if (!stage_contract_change(transaction.hash(), std::move(change.value()))) {
                 return TransactionProveError::InvalidContractPayload;
             }
         }

--- a/sources/network/network_service.cpp
+++ b/sources/network/network_service.cpp
@@ -1930,7 +1930,8 @@ void NetworkService::message_received(const std::string &message,
     case MessageType::ConsensusBatchRequest:
     case MessageType::ConsensusBatchData:
     case MessageType::ConsensusSyncRequest:
-    case MessageType::ConsensusSyncResponse: {
+    case MessageType::ConsensusSyncResponse:
+    case MessageType::ConsensusIntent: {
         if (node->consensus() != nullptr) {
             node->consensus()->receive_network_message(type, status, serialized, responder, identifier);
         }

--- a/spec/consensus/identity_bft_shadow.qnt
+++ b/spec/consensus/identity_bft_shadow.qnt
@@ -19,6 +19,12 @@ module shadow_consensus {
     branch: str,
   }
 
+  type ValidatorLock = {
+    validator: int,
+    height: int,
+    branch: str,
+  }
+
   pure val validators = Set(0, 1, 2, 3)
   pure val honestValidators = Set(0, 1, 2)
   pure val heights = Set(1, 2, 3)
@@ -29,9 +35,14 @@ module shadow_consensus {
   var votes: Set[Vote]
   var timeoutVotes: Set[TimeoutVote]
   var honestChoices: Set[HonestChoice]
+  var durableChoices: Set[HonestChoice]
+  var validatorLocks: Set[ValidatorLock]
+  var offlineValidators: Set[int]
   var availableData: Set[str]
   var currentRound: int
   var finalized: Set[str]
+  var activeEpoch: int
+  var preparedEpoch: int
 
   pure def voteOf(validator: int, height: int, round: int, branch: str): Vote = {
     validator: validator,
@@ -53,6 +64,12 @@ module shadow_consensus {
     branch: branch,
   }
 
+  pure def lockOf(validator: int, height: int, branch: str): ValidatorLock = {
+    validator: validator,
+    height: height,
+    branch: branch,
+  }
+
   def hasVote(validator: int, height: int, round: int, branch: str): bool =
     voteOf(validator, height, round, branch).in(votes)
 
@@ -70,9 +87,14 @@ module shadow_consensus {
     votes' = Set(),
     timeoutVotes' = Set(),
     honestChoices' = Set(),
+    durableChoices' = Set(),
+    validatorLocks' = Set(),
+    offlineValidators' = Set(),
     availableData' = Set(),
     currentRound' = 0,
     finalized' = Set(),
+    activeEpoch' = 1,
+    preparedEpoch' = 0,
   }
 
   action publishData(branch: str): bool = all {
@@ -80,9 +102,14 @@ module shadow_consensus {
     votes' = votes,
     timeoutVotes' = timeoutVotes,
     honestChoices' = honestChoices,
+    durableChoices' = durableChoices,
+    validatorLocks' = validatorLocks,
+    offlineValidators' = offlineValidators,
     availableData' = availableData.union(Set(branch)),
     currentRound' = currentRound,
     finalized' = finalized,
+    activeEpoch' = activeEpoch,
+    preparedEpoch' = preparedEpoch,
   }
 
   action vote(validator: int, height: int, round: int, branch: str): bool = all {
@@ -90,32 +117,51 @@ module shadow_consensus {
     height.in(heights),
     round == currentRound,
     branch.in(availableData),
+    not(validator.in(offlineValidators)),
     not(hasVote(validator, height, round, branch)),
     not(validator.in(honestValidators)) or
       honestChoices.filter(choice =>
-        choice.validator == validator and choice.branch != branch).size() == 0,
+        choice.validator == validator and choice.height == height and
+          choice.round == round and choice.branch != branch).size() == 0,
+    not(validator.in(honestValidators)) or
+      validatorLocks.filter(lock =>
+        lock.validator == validator and lock.height >= height and lock.branch != branch).size() == 0,
     votes' = votes.union(Set(voteOf(validator, height, round, branch))),
     timeoutVotes' = timeoutVotes,
     honestChoices' = if (validator.in(honestValidators))
       honestChoices.union(Set(choiceOf(validator, height, round, branch)))
     else
       honestChoices,
+    durableChoices' = if (validator.in(honestValidators))
+      durableChoices.union(Set(choiceOf(validator, height, round, branch)))
+    else
+      durableChoices,
+    validatorLocks' = validatorLocks,
+    offlineValidators' = offlineValidators,
     availableData' = availableData,
     currentRound' = currentRound,
     finalized' = finalized,
+    activeEpoch' = activeEpoch,
+    preparedEpoch' = preparedEpoch,
   }
 
   action timeout(validator: int, height: int, round: int): bool = all {
     validator.in(validators),
     height.in(heights),
     round == currentRound,
+    not(validator.in(offlineValidators)),
     not(hasTimeoutVote(validator, height, round)),
     votes' = votes,
     timeoutVotes' = timeoutVotes.union(Set(timeoutVoteOf(validator, height, round))),
     honestChoices' = honestChoices,
+    durableChoices' = durableChoices,
+    validatorLocks' = validatorLocks,
+    offlineValidators' = offlineValidators,
     availableData' = availableData,
     currentRound' = currentRound,
     finalized' = finalized,
+    activeEpoch' = activeEpoch,
+    preparedEpoch' = preparedEpoch,
   }
 
   action advanceRound(height: int, round: int): bool = all {
@@ -125,9 +171,98 @@ module shadow_consensus {
     votes' = votes,
     timeoutVotes' = timeoutVotes,
     honestChoices' = honestChoices,
+    durableChoices' = durableChoices,
+    validatorLocks' = validatorLocks,
+    offlineValidators' = offlineValidators,
     availableData' = availableData,
     currentRound' = round + 1,
     finalized' = finalized,
+    activeEpoch' = activeEpoch,
+    preparedEpoch' = preparedEpoch,
+  }
+
+  action lockCertificate(validator: int, height: int, branch: str): bool = all {
+    validator.in(honestValidators),
+    height.in(heights),
+    certificate(height, branch),
+    not(validator.in(offlineValidators)),
+    not(durableChoices.exists(choice =>
+      choice.validator == validator and choice.height <= height and choice.branch != branch)),
+    votes' = votes,
+    timeoutVotes' = timeoutVotes,
+    honestChoices' = honestChoices,
+    durableChoices' = durableChoices,
+    validatorLocks' = validatorLocks.union(Set(lockOf(validator, height, branch))),
+    offlineValidators' = offlineValidators,
+    availableData' = availableData,
+    currentRound' = currentRound,
+    finalized' = finalized,
+    activeEpoch' = activeEpoch,
+    preparedEpoch' = preparedEpoch,
+  }
+
+  action crash(validator: int): bool = all {
+    validator.in(honestValidators),
+    not(validator.in(offlineValidators)),
+    votes' = votes,
+    timeoutVotes' = timeoutVotes,
+    honestChoices' = honestChoices.filter(choice => choice.validator != validator),
+    durableChoices' = durableChoices,
+    validatorLocks' = validatorLocks,
+    offlineValidators' = offlineValidators.union(Set(validator)),
+    availableData' = availableData,
+    currentRound' = currentRound,
+    finalized' = finalized,
+    activeEpoch' = activeEpoch,
+    preparedEpoch' = preparedEpoch,
+  }
+
+  action restart(validator: int): bool = all {
+    validator.in(offlineValidators),
+    votes' = votes,
+    timeoutVotes' = timeoutVotes,
+    honestChoices' = honestChoices.union(
+      durableChoices.filter(choice => choice.validator == validator)),
+    durableChoices' = durableChoices,
+    validatorLocks' = validatorLocks,
+    offlineValidators' = offlineValidators.exclude(Set(validator)),
+    availableData' = availableData,
+    currentRound' = currentRound,
+    finalized' = finalized,
+    activeEpoch' = activeEpoch,
+    preparedEpoch' = preparedEpoch,
+  }
+
+  action prepareNextEpoch: bool = all {
+    preparedEpoch == 0,
+    finalized.size() > 0,
+    votes' = votes,
+    timeoutVotes' = timeoutVotes,
+    honestChoices' = honestChoices,
+    durableChoices' = durableChoices,
+    validatorLocks' = validatorLocks,
+    offlineValidators' = offlineValidators,
+    availableData' = availableData,
+    currentRound' = currentRound,
+    finalized' = finalized,
+    activeEpoch' = activeEpoch,
+    preparedEpoch' = activeEpoch + 2,
+  }
+
+  action activatePreparedEpoch: bool = all {
+    preparedEpoch == activeEpoch + 2,
+    finalized.size() > 0,
+    votes' = votes,
+    timeoutVotes' = timeoutVotes,
+    honestChoices' = honestChoices,
+    durableChoices' = durableChoices,
+    validatorLocks' = validatorLocks,
+    offlineValidators' = offlineValidators,
+    availableData' = availableData,
+    currentRound' = currentRound,
+    finalized' = finalized,
+    activeEpoch' = preparedEpoch,
+    preparedEpoch' = 0,
   }
 
   action finalize(branch: str): bool = all {
@@ -138,18 +273,28 @@ module shadow_consensus {
     votes' = votes,
     timeoutVotes' = timeoutVotes,
     honestChoices' = honestChoices,
+    durableChoices' = durableChoices,
+    validatorLocks' = validatorLocks,
+    offlineValidators' = offlineValidators,
     availableData' = availableData,
     currentRound' = currentRound,
     finalized' = finalized.union(Set(branch)),
+    activeEpoch' = activeEpoch,
+    preparedEpoch' = preparedEpoch,
   }
 
   action stutter = all {
     votes' = votes,
     timeoutVotes' = timeoutVotes,
     honestChoices' = honestChoices,
+    durableChoices' = durableChoices,
+    validatorLocks' = validatorLocks,
+    offlineValidators' = offlineValidators,
     availableData' = availableData,
     currentRound' = currentRound,
     finalized' = finalized,
+    activeEpoch' = activeEpoch,
+    preparedEpoch' = preparedEpoch,
   }
 
   action step = any {
@@ -179,6 +324,22 @@ module shadow_consensus {
       nondet branch = branches.oneOf()
       finalize(branch)
     },
+    {
+      nondet validator = honestValidators.oneOf()
+      nondet height = heights.oneOf()
+      nondet branch = branches.oneOf()
+      lockCertificate(validator, height, branch)
+    },
+    {
+      nondet validator = honestValidators.oneOf()
+      crash(validator)
+    },
+    {
+      nondet validator = honestValidators.oneOf()
+      restart(validator)
+    },
+    prepareNextEpoch,
+    activatePreparedEpoch,
     stutter,
   }
 
@@ -191,6 +352,35 @@ module shadow_consensus {
         rounds.forall(round =>
           not(hasVote(validator, height, round, "A")
             and hasVote(validator, height, round, "B")))))
+
+  val noDurableDoubleVote =
+    honestValidators.forall(validator =>
+      heights.forall(height =>
+        rounds.forall(round =>
+          not(durableChoices.exists(choice =>
+            choice.validator == validator and choice.height == height and
+              choice.round == round and choice.branch == "A")
+            and durableChoices.exists(choice =>
+              choice.validator == validator and choice.height == height and
+                choice.round == round and choice.branch == "B")))))
+
+  val restartRestoresDurableVote =
+    honestValidators.forall(validator =>
+      not(validator.in(offlineValidators)) implies
+        durableChoices.filter(choice => choice.validator == validator)
+          .forall(choice => choice.in(honestChoices)))
+
+  val lockDoesNotConflictWithDurableVote =
+    validatorLocks.forall(lock =>
+      not(durableChoices.exists(choice =>
+        choice.validator == lock.validator and choice.height <= lock.height and
+          choice.branch != lock.branch)))
+
+  val epochActivationIsTwoStep =
+    preparedEpoch == 0 or preparedEpoch == activeEpoch + 2
+
+  val epochActivationRequiresFinality =
+    activeEpoch == 1 or finalized.size() > 0
 
   val noHonestBranchSwitch =
     honestValidators.forall(validator =>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,8 @@ add_core_test_executable(extrachain-token-registry token_registry.cpp)
 add_core_test_executable(extrachain-dag-recovery dag_recovery.cpp)
 add_core_test_executable(extrachain-runtime-tests runtime/runtime_test.cpp)
 add_core_test_executable(extrachain-consensus-tests consensus_test.cpp)
+add_core_test_executable(extrachain-consensus-protocol-tests consensus_protocol_test.cpp)
+add_core_test_executable(extrachain-consensus-network-tests consensus_network_test.cpp)
 add_core_test_executable(extrachain-consensus-benchmark consensus_benchmark.cpp)
 
 if(EXTRACHAIN_BUILD_QT_COMPAT_TESTS)
@@ -71,10 +73,12 @@ add_test(NAME token-registry COMMAND extrachain-token-registry)
 add_test(NAME dag-recovery COMMAND extrachain-dag-recovery)
 add_test(NAME runtime COMMAND extrachain-runtime-tests)
 add_test(NAME consensus COMMAND extrachain-consensus-tests)
+add_test(NAME consensus-protocol COMMAND extrachain-consensus-protocol-tests)
+add_test(NAME consensus-network COMMAND extrachain-consensus-network-tests)
 if(EXTRACHAIN_BUILD_QT_COMPAT_TESTS)
     add_test(NAME qt-compat COMMAND extrachain-qt-compat-tests)
 endif()
-set(EXTRACHAIN_TEST_NAMES core-unit amount-roundtrip sync-roundtrip native-balance token-registry dag-recovery runtime consensus)
+set(EXTRACHAIN_TEST_NAMES core-unit amount-roundtrip sync-roundtrip native-balance token-registry dag-recovery runtime consensus consensus-protocol consensus-network)
 if(EXTRACHAIN_BUILD_LEGACY_TESTS)
     list(APPEND EXTRACHAIN_TEST_NAMES legacy-monolith)
 endif()
@@ -104,6 +108,9 @@ set(EXTRACHAIN_HEADER_CHECKS
     contracts/contract_manager.h
     contracts/wasm_runtime.h
     consensus/consensus_engine.h
+    consensus/consensus_protocol.h
+    consensus/intent_store.h
+    consensus/light_client.h
     consensus/consensus_service.h
     consensus/consensus_types.h
     consensus/peer_authenticator.h

--- a/tests/consensus_network_test.cpp
+++ b/tests/consensus_network_test.cpp
@@ -1,0 +1,541 @@
+#include <algorithm>
+#include <cstdio>
+#include <filesystem>
+#include <memory>
+#include <numeric>
+#include <string>
+#include <vector>
+
+#include "consensus/consensus_engine.h"
+#include "consensus/light_client.h"
+#include "consensus/validator_set.h"
+#include "utils/exc_utils.h"
+
+namespace {
+    using namespace ExtraChain::Consensus;
+
+    struct Committee {
+        Actor<KeyPrivate>              governance;
+        std::vector<Actor<KeyPrivate>> actors;
+        std::vector<KeyPrivate>        keys;
+        ValidatorSet                   document;
+        ValidatorSetView               view;
+
+        Committee()
+            : view(create(1)) {
+        }
+
+        Committee(const Actor<KeyPrivate>& network, std::uint64_t epoch)
+            : governance(network)
+            , view(create(epoch)) {
+        }
+
+        ValidatorSetView create(std::uint64_t epoch) {
+            if (governance.empty()) {
+                governance.create(ActorType::Service);
+            }
+            std::vector<ValidatorRecord> records;
+            for (std::size_t index = 0; index < 7; ++index) {
+                Actor<KeyPrivate> actor;
+                actor.create(ActorType::Service);
+                KeyPrivate key;
+                key.generate_random();
+                auto record = make_validator_record(governance.id(),
+                                                    epoch,
+                                                    actor,
+                                                    key,
+                                                    "validator-" + std::to_string(index),
+                                                    0);
+                if (!record.has_value()) {
+                    std::abort();
+                }
+                actors.push_back(actor);
+                keys.push_back(key);
+                records.push_back(record.value());
+            }
+            auto validator_set = make_validator_set(governance.id(), epoch, std::move(records), governance);
+            if (!validator_set.has_value()) {
+                std::abort();
+            }
+            document    = validator_set.value();
+            auto result = ValidatorSetView::create(document);
+            if (!result.has_value()) {
+                std::abort();
+            }
+            return result.value();
+        }
+
+        std::size_t index_for(std::string_view validator_id) const {
+            for (std::size_t index = 0; index < keys.size(); ++index) {
+                if (validator_id_for(keys[index].public_key()) == validator_id) {
+                    return index;
+                }
+            }
+            std::abort();
+        }
+    };
+
+    SectionBatchData batch_data(const Proposal& proposal) {
+        std::vector<std::pair<std::uint64_t, std::string>> sections;
+        for (auto section = proposal.batch.first_section; section <= proposal.batch.last_section; ++section) {
+            sections.emplace_back(section,
+                                  "network-section-" + std::to_string(proposal.header.height) + '-'
+                                      + std::to_string(section));
+        }
+        return SectionBatchData {
+            .header_hash = hash_header(proposal.header),
+            .manifest    = proposal.batch,
+            .sections    = std::move(sections),
+        };
+    }
+
+    SectionBatchManifest batch_manifest(std::uint64_t height, std::string extra_hash = {}) {
+        const auto                                         first = (height - 1) * ShadowSectionInterval + 1;
+        std::vector<std::pair<std::uint64_t, std::string>> sections;
+        std::uint64_t                                      payload_bytes = 0;
+        for (auto section = first; section < first + ShadowSectionInterval; ++section) {
+            auto bytes = "network-section-" + std::to_string(height) + '-' + std::to_string(section);
+            payload_bytes += bytes.size();
+            sections.emplace_back(section, std::move(bytes));
+        }
+        std::vector<std::string> hashes {
+            "network-transaction-" + std::to_string(height) + "-a",
+            "network-transaction-" + std::to_string(height) + "-b",
+        };
+        if (!extra_hash.empty()) {
+            hashes.push_back(std::move(extra_hash));
+        }
+        return SectionBatchManifest {
+            .first_section      = first,
+            .last_section       = first + ShadowSectionInterval - 1,
+            .transaction_hashes = hashes,
+            .transaction_root   = calculate_transaction_root(hashes),
+            .data_root          = calculate_data_root(sections),
+            .previous_section_root =
+                height == 1 ? "activation-root" : "network-root-" + std::to_string(height - 1),
+            .payload_bytes = payload_bytes,
+        };
+    }
+
+    SectionBatchManifest epoch_batch_manifest(std::uint64_t height,
+                                              std::uint64_t first,
+                                              std::string   previous_root,
+                                              std::string   extra_hash = {}) {
+        std::vector<std::pair<std::uint64_t, std::string>> sections;
+        std::uint64_t                                      payload_bytes = 0;
+        for (auto section = first; section < first + ShadowSectionInterval; ++section) {
+            auto bytes = "network-section-" + std::to_string(height) + '-' + std::to_string(section);
+            payload_bytes += bytes.size();
+            sections.emplace_back(section, std::move(bytes));
+        }
+        std::vector<std::string> hashes {
+            "epoch-transaction-" + std::to_string(height) + "-a",
+            "epoch-transaction-" + std::to_string(height) + "-b",
+        };
+        if (!extra_hash.empty()) {
+            hashes.push_back(std::move(extra_hash));
+        }
+        return SectionBatchManifest {
+            .first_section         = first,
+            .last_section          = first + ShadowSectionInterval - 1,
+            .transaction_hashes    = hashes,
+            .transaction_root      = calculate_transaction_root(hashes),
+            .data_root             = calculate_data_root(sections),
+            .previous_section_root = std::move(previous_root),
+            .payload_bytes         = payload_bytes,
+        };
+    }
+} // namespace
+
+int main() {
+    using namespace ExtraChain::Consensus;
+
+    int        passed = 0;
+    int        failed = 0;
+    const auto check  = [&](const char* name, bool result) {
+        std::printf("  [%s] %s\n", result ? "PASS" : "FAIL", name);
+        result ? ++passed : ++failed;
+    };
+
+    Committee                committee;
+    Committee                next_committee(committee.governance, 3);
+    Committee                third_committee(committee.governance, 5);
+    std::vector<KeyPrivate>  governance_keys(5);
+    std::vector<std::string> governance_public_keys;
+    for (auto& key : governance_keys) {
+        key.generate_random();
+        governance_public_keys.push_back(Utils::to_base64(key.public_key()));
+    }
+    const auto governance_policy =
+        make_multisig_policy(committee.governance.id(), GovernanceThreshold, governance_public_keys);
+    EpochChangeV1 epoch_change {
+        .network_id                 = committee.governance.id(),
+        .current_epoch              = 1,
+        .activation_epoch           = 3,
+        .activation_height          = 13,
+        .current_validator_set_hash = committee.view.hash(),
+        .next_validator_set_hash    = next_committee.view.hash(),
+        .registry_document_hash     = Utils::calculate_hash("network-epoch-3-registry"),
+    };
+    for (std::size_t index = 0; index < next_committee.actors.size(); ++index) {
+        epoch_change.operators.push_back(OperatorAttestation {
+            .operator_id_hash     = Utils::calculate_hash("network-operator-" + std::to_string(index)),
+            .actor_id             = next_committee.actors[index].id(),
+            .node_identifier      = "validator-" + std::to_string(index),
+            .consensus_public_key = Utils::to_base64(next_committee.keys[index].public_key()),
+            .document_hash        = Utils::calculate_hash("network-attestation-" + std::to_string(index)),
+        });
+    }
+    epoch_change.authorization = authorize_action(governance_policy.value(),
+                                                  20,
+                                                  epoch_change_action_hash(epoch_change),
+                                                  { governance_keys[0], governance_keys[1], governance_keys[2] })
+                                     .value();
+    const auto    epoch_action_hash = epoch_change_action_hash(epoch_change);
+    EpochChangeV1 third_epoch_change {
+        .network_id                 = committee.governance.id(),
+        .current_epoch              = 3,
+        .activation_epoch           = 5,
+        .activation_height          = 16,
+        .current_validator_set_hash = next_committee.view.hash(),
+        .next_validator_set_hash    = third_committee.view.hash(),
+        .registry_document_hash     = Utils::calculate_hash("network-epoch-5-registry"),
+    };
+    for (std::size_t index = 0; index < third_committee.actors.size(); ++index) {
+        third_epoch_change.operators.push_back(OperatorAttestation {
+            .operator_id_hash     = Utils::calculate_hash("network-epoch-5-operator-" + std::to_string(index)),
+            .actor_id             = third_committee.actors[index].id(),
+            .node_identifier      = "validator-" + std::to_string(index),
+            .consensus_public_key = Utils::to_base64(third_committee.keys[index].public_key()),
+            .document_hash        = Utils::calculate_hash("network-epoch-5-attestation-" + std::to_string(index)),
+        });
+    }
+    third_epoch_change.authorization =
+        authorize_action(governance_policy.value(),
+                         21,
+                         epoch_change_action_hash(third_epoch_change),
+                         { governance_keys[0], governance_keys[1], governance_keys[2] })
+            .value();
+    const auto third_epoch_action_hash = epoch_change_action_hash(third_epoch_change);
+    const auto root =
+        std::filesystem::temp_directory_path() / ("extrachain-shadow-network-" + Utils::generate_random_hex(8));
+    std::filesystem::create_directories(root);
+
+    std::vector<std::unique_ptr<ConsensusEngine>> engines;
+    const auto                                    make_engine = [&](std::size_t index) {
+        auto engine =
+            std::make_unique<ConsensusEngine>(committee.view,
+                                              ValidatorIdentity { .validator_id = validator_id_for(
+                                                                      committee.keys[index].public_key()),
+                                                                                                     .key = committee.keys[index] },
+                                              std::make_unique<SafetyStore>(
+                                                  root / ("validator-" + std::to_string(index) + ".sqlite")));
+        if (!engine->initialize().has_value()) {
+            std::abort();
+        }
+        return engine;
+    };
+    for (std::size_t index = 0; index < committee.keys.size(); ++index) {
+        engines.push_back(make_engine(index));
+    }
+
+    bool quorum_guard_checked = false;
+    for (std::uint64_t height = 1; height <= 12; ++height) {
+        const auto& leader       = committee.view.leader(height, 0);
+        const auto  leader_index = committee.index_for(leader.validator_id);
+        const auto  proposal =
+            engines[leader_index]->make_proposal(batch_manifest(height,
+                                                                height == 10 ? epoch_action_hash : std::string {}),
+                                                 "network-root-" + std::to_string(height));
+        check("scheduled leader proposes a canonical network batch", proposal.has_value());
+        if (!proposal.has_value()) {
+            break;
+        }
+
+        const auto               data = batch_data(proposal.value());
+        std::vector<std::size_t> delivery_order(engines.size());
+        std::iota(delivery_order.begin(), delivery_order.end(), 0);
+        std::rotate(delivery_order.begin(),
+                    delivery_order.begin() + static_cast<std::ptrdiff_t>(height % delivery_order.size()),
+                    delivery_order.end());
+
+        std::vector<Vote> votes;
+        for (const auto index : delivery_order) {
+            if (index != leader_index) {
+                check("validator observes a network proposal",
+                      engines[index]->observe_proposal(proposal.value()).has_value());
+            }
+            check("validator durably stages network data before voting",
+                  engines[index]->stage_batch(data).has_value());
+            const auto vote = engines[index]->accept_proposal(proposal.value());
+            check("validator votes for a safe staged network proposal", vote.has_value());
+            if (vote.has_value()) {
+                votes.push_back(vote.value());
+            }
+        }
+
+        std::reverse(votes.begin(), votes.end());
+        std::optional<QuorumCertificate> certificate;
+        for (std::size_t index = 0; index < votes.size(); ++index) {
+            const auto accepted = engines[leader_index]->accept_vote(votes[index]);
+            check("leader accepts reordered network vote", accepted.has_value());
+            if (!quorum_guard_checked && index == 3) {
+                check("four of seven votes cannot form a certificate",
+                      accepted.has_value() && !accepted.value().certificate.has_value());
+                quorum_guard_checked = true;
+            }
+            if (accepted.has_value() && accepted.value().certificate.has_value()) {
+                certificate = accepted.value().certificate;
+            }
+        }
+        check("five of seven votes form a certificate", certificate.has_value());
+        if (!certificate.has_value()) {
+            break;
+        }
+
+        for (auto& engine : engines) {
+            check("all connected validators accept the certificate",
+                  engine->accept_certificate(certificate.value()).has_value());
+        }
+
+        if (height % 4 == 0) {
+            const auto restart_index = static_cast<std::size_t>((height / 4) % engines.size());
+            const auto state_before  = engines[restart_index]->safety_state();
+            engines[restart_index].reset();
+            engines[restart_index] = make_engine(restart_index);
+            check("restarted validator restores the certified height",
+                  engines[restart_index]->safety_state().highest_certificate.has_value()
+                      && state_before.highest_certificate.has_value()
+                      && engines[restart_index]->safety_state().highest_certificate.value().height
+                             == state_before.highest_certificate.value().height);
+            check("restarted validator restores finality",
+                  engines[restart_index]->safety_state().finalized_height == state_before.finalized_height);
+        }
+    }
+
+    const auto expected_finalized = std::uint64_t(10);
+    check("seven-node run finalizes the three-chain prefix",
+          std::ranges::all_of(engines, [expected_finalized](const auto& engine) {
+              return engine->safety_state().finalized_height == expected_finalized;
+          }));
+    const auto inclusion = engines.front()->transaction_inclusion_proof("network-transaction-1-b");
+    check("old finalized network transaction has an inclusion proof",
+          inclusion.has_value() && inclusion.value().has_value()
+              && engines.front()->verify_transaction_inclusion_proof(inclusion.value().value()));
+    auto light_client = LightClientVerifier::create(committee.document);
+    check("light client starts from the trusted validator set", light_client.has_value());
+    check("light client verifies finality and transaction inclusion without DAG state",
+          light_client.has_value() && inclusion.has_value() && inclusion.value().has_value()
+              && light_client.value().verify_transaction_proof(inclusion.value().value()));
+    auto changed_inclusion             = inclusion.value().value();
+    changed_inclusion.transaction_hash = "network-transaction-changed";
+    check("light client rejects a changed transaction proof",
+          light_client.has_value() && !light_client.value().verify_transaction_proof(changed_inclusion));
+
+    const auto epoch_inclusion = engines.front()->transaction_inclusion_proof(epoch_action_hash);
+    check("finalized epoch action has an inclusion proof",
+          epoch_inclusion.has_value() && epoch_inclusion.value().has_value());
+    const auto epoch_scheduled = light_client.value().schedule_epoch(epoch_change,
+                                                                     next_committee.document,
+                                                                     governance_policy.value(),
+                                                                     epoch_inclusion.value().value(),
+                                                                     20);
+    check("light client accepts the governed two-step epoch", epoch_scheduled.has_value());
+    const auto light_client_state_path = root / "light-client.msgpack";
+    check("light client writes its pending trust chain atomically",
+          light_client.value().save(light_client_state_path).has_value());
+    auto restored_light_client = LightClientVerifier::load(light_client_state_path);
+    check("light client restores its pending trust chain",
+          restored_light_client.has_value() && restored_light_client.value().pending_validators().has_value()
+              && restored_light_client.value().pending_validators().value().document().epoch == 3);
+    if (restored_light_client.has_value()) {
+        light_client = std::move(restored_light_client);
+    }
+    const auto bootstrap =
+        make_epoch_bootstrap(epoch_change, next_committee.document, epoch_inclusion.value().value());
+    check("epoch handover binds the old decision certificate", bootstrap.has_value());
+    const auto next_view = ValidatorSetView::create_epoch_transition(next_committee.document,
+                                                                     epoch_change,
+                                                                     governance_policy.value(),
+                                                                     10,
+                                                                     20);
+    check("next committee is valid for the governed handover", next_view.has_value());
+
+    std::vector<std::unique_ptr<ConsensusEngine>> next_engines;
+    for (std::size_t index = 0; index < next_committee.keys.size(); ++index) {
+        auto engine =
+            std::make_unique<ConsensusEngine>(next_view.value(),
+                                              ValidatorIdentity {
+                                                  .validator_id =
+                                                      validator_id_for(next_committee.keys[index].public_key()),
+                                                  .key = next_committee.keys[index],
+                                              },
+                                              std::make_unique<SafetyStore>(
+                                                  root
+                                                  / ("epoch-3-validator-" + std::to_string(index) + ".sqlite")),
+                                              ConsensusEngine::ProposalValidator {},
+                                              bootstrap.value());
+        check("next-epoch validator starts at the global handover height", engine->initialize().has_value());
+        next_engines.push_back(std::move(engine));
+    }
+    check("new epoch genesis continues the global height",
+          std::ranges::all_of(next_engines, [](const auto& engine) {
+              return engine->genesis_certificate().height == 12;
+          }));
+
+    auto next_first    = bootstrap.value().first_dag_section;
+    auto previous_root = bootstrap.value().previous_section_root;
+    for (std::uint64_t height = 13; height <= 15; ++height) {
+        const auto& leader       = next_view.value().leader(height, 0);
+        const auto  leader_index = next_committee.index_for(leader.validator_id);
+        const auto  proposal =
+            next_engines[leader_index]->make_proposal(epoch_batch_manifest(height,
+                                                                           next_first,
+                                                                           previous_root,
+                                                                           height == 13 ? third_epoch_action_hash
+                                                                                        : std::string {}),
+                                                      "epoch-root-" + std::to_string(height));
+        check("new epoch proposes on the global chain", proposal.has_value());
+        const auto                       data = batch_data(proposal.value());
+        std::optional<QuorumCertificate> certificate;
+        for (std::size_t index = 0; index < next_engines.size(); ++index) {
+            if (index != leader_index) {
+                check("new epoch observes the handover proposal",
+                      next_engines[index]->observe_proposal(proposal.value()).has_value());
+            }
+            check("new epoch stages handover data", next_engines[index]->stage_batch(data).has_value());
+            const auto vote = next_engines[index]->accept_proposal(proposal.value());
+            check("new epoch validator votes", vote.has_value());
+            if (vote.has_value()) {
+                const auto accepted = next_engines[leader_index]->accept_vote(vote.value());
+                if (accepted.has_value() && accepted.value().certificate.has_value()) {
+                    certificate = accepted.value().certificate;
+                }
+            }
+        }
+        check("new epoch forms a five-of-seven certificate", certificate.has_value());
+        for (auto& engine : next_engines) {
+            check("new epoch accepts its certificate",
+                  engine->accept_certificate(certificate.value()).has_value());
+        }
+        next_first += ShadowSectionInterval;
+        previous_root = "epoch-root-" + std::to_string(height);
+    }
+
+    const auto new_epoch_inclusion = next_engines.front()->transaction_inclusion_proof("epoch-transaction-13-a");
+    check("new epoch creates a finality proof",
+          new_epoch_inclusion.has_value() && new_epoch_inclusion.value().has_value());
+    check("light client verifies and activates the new epoch",
+          new_epoch_inclusion.has_value() && new_epoch_inclusion.value().has_value()
+              && light_client.value().advance(new_epoch_inclusion.value().value().finality_proof).has_value()
+              && light_client.value().active_validators().document().epoch == 3);
+    check("light client rejects a finalized proof below its trusted height",
+          inclusion.has_value() && inclusion.value().has_value()
+              && !light_client.value().advance(inclusion.value().value().finality_proof).has_value());
+    check("light client saves the promoted trust chain",
+          light_client.value().save(light_client_state_path).has_value());
+    const auto promoted_light_client = LightClientVerifier::load(light_client_state_path);
+    check("light client restores the promoted epoch and trusted height",
+          promoted_light_client.has_value()
+              && promoted_light_client.value().active_validators().document().epoch == 3
+              && promoted_light_client.value().trusted_height() == 13);
+    const auto third_epoch_inclusion = next_engines.front()->transaction_inclusion_proof(third_epoch_action_hash);
+    check("second governed epoch action has an inclusion proof",
+          third_epoch_inclusion.has_value() && third_epoch_inclusion.value().has_value());
+    check("light client schedules a second validator transition",
+          third_epoch_inclusion.has_value() && third_epoch_inclusion.value().has_value()
+              && light_client.value()
+                     .schedule_epoch(third_epoch_change,
+                                     third_committee.document,
+                                     governance_policy.value(),
+                                     third_epoch_inclusion.value().value(),
+                                     21)
+                     .has_value());
+    check("light client persists trust across two validator transitions",
+          light_client.value().save(light_client_state_path).has_value()
+              && LightClientVerifier::load(light_client_state_path).has_value());
+
+    const auto third_bootstrap =
+        make_epoch_bootstrap(third_epoch_change, third_committee.document, third_epoch_inclusion.value().value());
+    const auto third_view = ValidatorSetView::create_epoch_transition(third_committee.document,
+                                                                      third_epoch_change,
+                                                                      governance_policy.value(),
+                                                                      13,
+                                                                      21);
+    check("second handover has a valid bootstrap and validator set",
+          third_bootstrap.has_value() && third_view.has_value());
+    std::vector<std::unique_ptr<ConsensusEngine>> third_engines;
+    for (std::size_t index = 0; index < third_committee.keys.size(); ++index) {
+        auto engine =
+            std::make_unique<ConsensusEngine>(third_view.value(),
+                                              ValidatorIdentity {
+                                                  .validator_id =
+                                                      validator_id_for(third_committee.keys[index].public_key()),
+                                                  .key = third_committee.keys[index],
+                                              },
+                                              std::make_unique<SafetyStore>(
+                                                  root
+                                                  / ("epoch-5-validator-" + std::to_string(index) + ".sqlite")),
+                                              ConsensusEngine::ProposalValidator {},
+                                              third_bootstrap.value());
+        check("second handover validator starts at the global height", engine->initialize().has_value());
+        third_engines.push_back(std::move(engine));
+    }
+
+    auto third_first         = third_bootstrap.value().first_dag_section;
+    auto third_previous_root = third_bootstrap.value().previous_section_root;
+    for (std::uint64_t height = 16; height <= 18; ++height) {
+        const auto& leader       = third_view.value().leader(height, 0);
+        const auto  leader_index = third_committee.index_for(leader.validator_id);
+        const auto  proposal     = third_engines[leader_index]->make_proposal(epoch_batch_manifest(height,
+                                                                                              third_first,
+                                                                                              third_previous_root),
+                                                                         "epoch-5-root-" + std::to_string(height));
+        check("second handover proposes on the global chain", proposal.has_value());
+        const auto                       data = batch_data(proposal.value());
+        std::optional<QuorumCertificate> certificate;
+        for (std::size_t index = 0; index < third_engines.size(); ++index) {
+            if (index != leader_index) {
+                check("second handover observes the proposal",
+                      third_engines[index]->observe_proposal(proposal.value()).has_value());
+            }
+            check("second handover stages data", third_engines[index]->stage_batch(data).has_value());
+            const auto vote = third_engines[index]->accept_proposal(proposal.value());
+            check("second handover validator votes", vote.has_value());
+            if (vote.has_value()) {
+                const auto accepted = third_engines[leader_index]->accept_vote(vote.value());
+                if (accepted.has_value() && accepted.value().certificate.has_value()) {
+                    certificate = accepted.value().certificate;
+                }
+            }
+        }
+        check("second handover forms a five-of-seven certificate", certificate.has_value());
+        for (auto& engine : third_engines) {
+            check("second handover accepts its certificate",
+                  engine->accept_certificate(certificate.value()).has_value());
+        }
+        third_first += ShadowSectionInterval;
+        third_previous_root = "epoch-5-root-" + std::to_string(height);
+    }
+
+    const auto epoch_five_inclusion = third_engines.front()->transaction_inclusion_proof("epoch-transaction-16-a");
+    check("second transition creates a finality proof",
+          epoch_five_inclusion.has_value() && epoch_five_inclusion.value().has_value());
+    check("light client activates the second validator transition",
+          epoch_five_inclusion.has_value() && epoch_five_inclusion.value().has_value()
+              && light_client.value().advance(epoch_five_inclusion.value().value().finality_proof).has_value()
+              && light_client.value().active_validators().document().epoch == 5
+              && light_client.value().trusted_height() == 16);
+    const auto saved_epoch_five  = light_client.value().save(light_client_state_path);
+    const auto loaded_epoch_five = LightClientVerifier::load(light_client_state_path);
+    check("light client restores trust after two completed transitions",
+          saved_epoch_five.has_value() && loaded_epoch_five.has_value()
+              && loaded_epoch_five.value().active_validators().document().epoch == 5);
+
+    third_engines.clear();
+    next_engines.clear();
+    engines.clear();
+    std::filesystem::remove_all(root);
+    std::printf("CONSENSUS NETWORK: %d pass, %d fail\n", passed, failed);
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/consensus_protocol_test.cpp
+++ b/tests/consensus_protocol_test.cpp
@@ -1,0 +1,436 @@
+#include <cstdio>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+#include "chain/transaction.h"
+#include "consensus/consensus_protocol.h"
+#include "consensus/intent_store.h"
+#include "consensus/validator_set.h"
+#include "utils/exc_utils.h"
+#include "utils/exc_utils_base64.h"
+
+namespace {
+    using namespace ExtraChain::Consensus;
+
+    Actor<KeyPrivate> make_actor(ActorType type = ActorType::Service) {
+        Actor<KeyPrivate> actor;
+        actor.create(type);
+        return actor;
+    }
+
+    std::vector<KeyPrivate> make_keys(std::size_t count) {
+        std::vector<KeyPrivate> result(count);
+        for (auto& key : result) {
+            key.generate_random();
+        }
+        return result;
+    }
+
+    std::vector<std::string> public_keys(const std::vector<KeyPrivate>& keys) {
+        std::vector<std::string> result;
+        result.reserve(keys.size());
+        for (const auto& key : keys) {
+            result.push_back(Utils::to_base64(key.public_key()));
+        }
+        return result;
+    }
+} // namespace
+
+int main() {
+    using namespace ExtraChain::Consensus;
+
+    int        passed = 0;
+    int        failed = 0;
+    const auto check  = [&](const char* name, bool result) {
+        std::printf("  [%s] %s\n", result ? "PASS" : "FAIL", name);
+        result ? ++passed : ++failed;
+    };
+
+    auto network      = make_actor();
+    auto sender       = make_actor(ActorType::User);
+    auto receiver     = make_actor(ActorType::User);
+    auto other_sender = make_actor(ActorType::User);
+
+    TransactionIntentV2 first {
+        .network_id           = network.id(),
+        .sender               = sender.id(),
+        .receiver             = receiver.id(),
+        .amount               = "1.25",
+        .operation            = IntentOperation::Transfer,
+        .account_nonce        = 1,
+        .valid_after_height   = 10,
+        .expires_after_height = 30,
+    };
+    const auto signed_first = make_intent(first, "memo-one", sender);
+    check("intent is signed without a DAG section", signed_first.has_value());
+    IntentEnvelope first_envelope { .intent = signed_first.value(), .metadata = "memo-one" };
+    const auto     sender_public_key = Utils::to_base64(sender.key().public_key());
+    check("signed intent verifies", verify_intent(first_envelope, sender_public_key));
+    const auto materialized = materialize_intent(first_envelope, 220, 14, { "previous-hash" });
+    check("consensus assigns a stable intent to a DAG section", materialized.has_value());
+    check("materialized intent keeps the user authorization",
+          materialized.has_value() && materialized.value().section() == SectionId(220)
+              && materialized.value().verify(sender.to_public()));
+    const auto restored_intent =
+        materialized.has_value()
+            ? intent_from_transaction(materialized.value())
+            : std::expected<IntentEnvelope, ConsensusError>(std::unexpected(ConsensusError::InvalidIntent));
+    check("materialized intent can be recovered from historical DAG data",
+          restored_intent.has_value()
+              && hash_intent(restored_intent.value().intent) == hash_intent(first_envelope.intent));
+    auto changed_materialization = materialized.value();
+    changed_materialization.set_amount(BigNumberFloat("2"));
+    changed_materialization.update_hash();
+    check("materialized intent rejects changed operation data",
+          !changed_materialization.verify(sender.to_public()));
+
+    auto changed_metadata     = first_envelope;
+    changed_metadata.metadata = "changed";
+    check("changed intent metadata is rejected", !verify_intent(changed_metadata, sender_public_key));
+    auto malformed_amount   = first;
+    malformed_amount.amount = "1e6";
+    check("non-decimal intent amount is rejected", !make_intent(malformed_amount, "memo", sender).has_value());
+    malformed_amount.amount = "0";
+    check("zero transfer intent is rejected", !make_intent(malformed_amount, "memo", sender).has_value());
+
+    IntentPool pool;
+    const auto first_hash = pool.submit(first_envelope, sender_public_key, 0, 10);
+    check("valid intent enters the bounded pool", first_hash.has_value());
+    check("duplicate intent is rejected", !pool.submit(first_envelope, sender_public_key, 0, 10).has_value());
+
+    auto second                  = first;
+    second.account_nonce         = 2;
+    const auto     signed_second = make_intent(second, "memo-two", sender);
+    IntentEnvelope second_envelope { .intent = signed_second.value(), .metadata = "memo-two" };
+    check("future sequential nonce enters the pool",
+          pool.submit(second_envelope, sender_public_key, 0, 10).has_value());
+
+    auto delayed                 = first;
+    delayed.sender               = other_sender.id();
+    delayed.valid_after_height   = 20;
+    delayed.expires_after_height = 40;
+    const auto signed_delayed    = make_intent(delayed, "delayed", other_sender);
+    IntentPool delayed_pool;
+    check("future-valid intent enters the pool",
+          delayed_pool
+              .submit(IntentEnvelope { .intent = signed_delayed.value(), .metadata = "delayed" },
+                      Utils::to_base64(other_sender.key().public_key()),
+                      0,
+                      10)
+              .has_value());
+    check("future-valid intent waits for its height", delayed_pool.ready({}, 19, 1, 1'024).empty());
+    check("future-valid intent becomes ready", delayed_pool.ready({}, 20, 1, 1'024).size() == 1);
+
+    auto gap              = first;
+    gap.account_nonce     = 65;
+    const auto signed_gap = make_intent(gap, "gap", sender);
+    check("nonce outside the bounded window is rejected",
+          !pool.submit(IntentEnvelope { .intent = signed_gap.value(), .metadata = "gap" },
+                       sender_public_key,
+                       0,
+                       10)
+               .has_value());
+
+    const auto selected = pool.ready({}, 10, 10, 1024 * 1024);
+    check("one batch selects one sequential nonce for a sender",
+          selected.size() == 1 && selected.front().intent.account_nonce == 1);
+    const auto next_selected = pool.ready({ { sender.id(), 1 } }, 10, 10, 1024 * 1024);
+    check("the next batch selects the next committed sender nonce",
+          next_selected.size() == 1 && next_selected.front().intent.account_nonce == 2);
+
+    auto contract_sender             = make_actor(ActorType::User);
+    auto competing_sender            = make_actor(ActorType::User);
+    auto contract_call               = first;
+    contract_call.sender             = contract_sender.id();
+    contract_call.amount             = "0";
+    contract_call.operation          = IntentOperation::ContractCall;
+    contract_call.account_nonce      = 1;
+    const auto signed_contract_call  = make_intent(contract_call, "call-a", contract_sender);
+    auto       competing_call        = contract_call;
+    competing_call.sender            = competing_sender.id();
+    const auto signed_competing_call = make_intent(competing_call, "call-b", competing_sender);
+    IntentPool contract_pool;
+    check("competing contract intents enter the pool",
+          signed_contract_call.has_value() && signed_competing_call.has_value()
+              && contract_pool
+                     .submit(IntentEnvelope { .intent = signed_contract_call.value(), .metadata = "call-a" },
+                             Utils::to_base64(contract_sender.key().public_key()),
+                             0,
+                             10)
+                     .has_value()
+              && contract_pool
+                     .submit(IntentEnvelope { .intent = signed_competing_call.value(), .metadata = "call-b" },
+                             Utils::to_base64(competing_sender.key().public_key()),
+                             0,
+                             10)
+                     .has_value());
+    check("one batch selects at most one contract mutation",
+          contract_pool.ready({}, 10, 10, 1024 * 1024).size() == 1);
+
+    auto large              = first;
+    large.sender            = other_sender.id();
+    large.account_nonce     = 1;
+    const auto signed_large = make_intent(large, std::string(4'096, 'x'), other_sender);
+    IntentPool size_limited_pool;
+    check("large intent enters the pool",
+          size_limited_pool
+              .submit(IntentEnvelope { .intent = signed_large.value(), .metadata = std::string(4'096, 'x') },
+                      Utils::to_base64(other_sender.key().public_key()),
+                      0,
+                      10)
+              .has_value());
+    check("small intent enters a pool with a large intent",
+          size_limited_pool.submit(first_envelope, sender_public_key, 0, 10).has_value());
+    const auto size_limited = size_limited_pool.ready({}, 10, 2, 1'024);
+    check("an oversized head does not block another sender",
+          size_limited.size() == 1 && size_limited.front().intent.sender == sender.id());
+    pool.erase({ first_hash.value() });
+    check("finalized intent leaves the pool", pool.size() == 1);
+    check("expired intent leaves the pool", pool.expire(31).size() == 1 && pool.size() == 0);
+
+    const auto store_root =
+        std::filesystem::temp_directory_path() / ("extrachain-intent-store-" + Utils::generate_random_hex(8));
+    const auto store_path = store_root / "intents.sqlite";
+    {
+        IntentStore store(store_path);
+        check("intent store opens with a durable WAL", store.open().has_value());
+        check("intent store persists an accepted intent", store.put(first_envelope).has_value());
+        check("intent store treats an identical write as idempotent", store.put(first_envelope).has_value());
+        check("intent store persists the next sender nonce", store.put(second_envelope).has_value());
+        const auto accepted = store.receipt(first_hash.value());
+        check("intent and accepted receipt are one durable operation",
+              accepted.has_value() && accepted.value().has_value()
+                  && accepted.value().value().status == IntentStatus::Accepted);
+        const auto pending = store.load_pending();
+        check("intent store reloads the pending envelope",
+              pending.has_value() && pending.value().size() == 2
+                  && hash_intent(pending.value().front().intent) == first_hash.value());
+    }
+    {
+        IntentStore restarted(store_path);
+        check("intent store reopens after restart", restarted.open().has_value());
+        const auto receipt = restarted.receipt(first_hash.value());
+        check("intent receipt survives restart",
+              receipt.has_value() && receipt.value().has_value()
+                  && receipt.value().value().status == IntentStatus::Accepted);
+        IntentReceipt finalized_receipt {
+            .intent_hash      = first_hash.value(),
+            .status           = IntentStatus::Finalized,
+            .consensus_height = 14,
+            .dag_section      = 280,
+            .position         = 0,
+        };
+        auto invalid_second_receipt        = finalized_receipt;
+        invalid_second_receipt.intent_hash = "wrong-hash";
+        invalid_second_receipt.position    = 1;
+        check("failed batch finalization rolls back every intent",
+              !restarted
+                   .commit_finalized(
+                       { { first_envelope, finalized_receipt }, { second_envelope, invalid_second_receipt } })
+                   .has_value());
+        const auto after_rollback        = restarted.load_pending();
+        const auto nonces_after_rollback = restarted.load_committed_nonces();
+        check("failed finalization keeps pending data and nonce",
+              after_rollback.has_value() && after_rollback.value().size() == 2 && nonces_after_rollback.has_value()
+                  && nonces_after_rollback.value().empty());
+        check("intent finalization and nonce advance are atomic",
+              restarted.commit_finalized({ { first_envelope, finalized_receipt } }).has_value());
+        check("exact finalization replay is idempotent",
+              restarted.commit_finalized({ { first_envelope, finalized_receipt } }).has_value());
+        check("expired pending intent closes atomically",
+              restarted.expire({ hash_intent(second_envelope.intent) }).has_value());
+        const auto pending = restarted.load_pending();
+        check("finalized intent does not return after restart", pending.has_value() && pending.value().empty());
+        const auto nonces = restarted.load_committed_nonces();
+        check("committed nonce survives restart",
+              nonces.has_value() && nonces.value().contains(sender.id()) && nonces.value().at(sender.id()) == 1);
+        const auto finalized = restarted.receipt(first_hash.value());
+        check("finalized receipt replaces the accepted receipt",
+              finalized.has_value() && finalized.value().has_value()
+                  && finalized.value().value().status == IntentStatus::Finalized);
+    }
+    std::filesystem::remove_all(store_root);
+
+    const std::vector<std::string> leaves { "tx-a", "tx-b", "tx-c", "tx-d", "tx-e" };
+    const auto                     root  = merkle_root(leaves);
+    const auto                     proof = make_merkle_proof(leaves, 2);
+    check("Merkle proof is built", proof.has_value());
+    check("Merkle proof verifies", verify_merkle_proof(leaves[2], proof.value(), root));
+    check("Merkle proof rejects changed data", !verify_merkle_proof("tx-x", proof.value(), root));
+    auto changed_proof                = proof.value();
+    changed_proof.siblings.front()[0] = changed_proof.siblings.front()[0] == '0' ? '1' : '0';
+    check("Merkle proof rejects a changed branch", !verify_merkle_proof(leaves[2], changed_proof, root));
+
+    auto       governance_keys   = make_keys(5);
+    const auto governance_policy = make_multisig_policy(network.id(), 3, public_keys(governance_keys));
+    check("governance policy accepts three of five", governance_policy.has_value());
+    auto changed_policy      = governance_policy.value();
+    changed_policy.threshold = 2;
+    check("changed governance policy hash is rejected", !verify_multisig_policy(changed_policy));
+    const auto authorization = authorize_action(governance_policy.value(),
+                                                7,
+                                                "validator-set-change",
+                                                { governance_keys[0], governance_keys[1], governance_keys[2] });
+    check("three governance keys authorize an action", authorization.has_value());
+    check("governance authorization verifies",
+          verify_authorization(governance_policy.value(), authorization.value(), 7));
+    check("old governance sequence is rejected",
+          !verify_authorization(governance_policy.value(), authorization.value(), 8));
+    check("two governance keys cannot authorize an action",
+          !authorize_action(governance_policy.value(),
+                            8,
+                            "insufficient",
+                            { governance_keys[0], governance_keys[1] })
+               .has_value());
+
+    ActivationManifestV1 activation {
+        .network_id             = network.id(),
+        .activation_height      = 2'000,
+        .activation_dag_section = 4'000,
+        .validator_set_hash     = "activation-set",
+    };
+    const auto activation_authorization =
+        authorize_action(governance_policy.value(),
+                         9,
+                         activation_action_hash(activation),
+                         { governance_keys[0], governance_keys[1], governance_keys[2] });
+    activation.authorization = activation_authorization.value();
+    check("future aligned Shadow activation verifies",
+          verify_activation_manifest(activation, governance_policy.value(), 1'500, 9));
+    const auto weak_governance_policy = make_multisig_policy(network.id(), 2, public_keys(governance_keys));
+    check("activation rejects a policy weaker than three of five",
+          !verify_activation_manifest(activation, weak_governance_policy.value(), 1'500, 9));
+    activation.activation_dag_section = 4'001;
+    check("unaligned Shadow activation is rejected",
+          !verify_activation_manifest(activation, governance_policy.value(), 1'500, 9));
+
+    EpochChangeV1 change {
+        .network_id                 = network.id(),
+        .current_epoch              = 4,
+        .activation_epoch           = 6,
+        .activation_height          = 1'000,
+        .current_validator_set_hash = "current-set",
+        .next_validator_set_hash    = "next-set",
+        .registry_document_hash     = "exdfs-registry",
+    };
+    std::vector<Actor<KeyPrivate>> operators;
+    std::vector<KeyPrivate>        consensus_keys;
+    for (std::size_t index = 0; index < 7; ++index) {
+        operators.push_back(make_actor());
+        KeyPrivate key;
+        key.generate_random();
+        consensus_keys.push_back(key);
+        change.operators.push_back(OperatorAttestation {
+            .operator_id_hash     = Utils::calculate_hash("operator-" + std::to_string(index)),
+            .actor_id             = operators.back().id(),
+            .node_identifier      = "node-" + std::to_string(index),
+            .consensus_public_key = Utils::to_base64(consensus_keys.back().public_key()),
+            .document_hash        = Utils::calculate_hash("attestation-" + std::to_string(index)),
+        });
+    }
+    const auto change_authorization =
+        authorize_action(governance_policy.value(),
+                         8,
+                         epoch_change_action_hash(change),
+                         { governance_keys[0], governance_keys[1], governance_keys[2] });
+    change.authorization = change_authorization.value();
+    check("two-step epoch change verifies", verify_epoch_change(change, governance_policy.value(), 900, 8));
+    auto duplicate_operator                          = change;
+    duplicate_operator.operators[1].operator_id_hash = duplicate_operator.operators[0].operator_id_hash;
+    duplicate_operator.authorization.action_hash     = epoch_change_action_hash(duplicate_operator);
+    check("duplicate operator identity is rejected",
+          !verify_epoch_change(duplicate_operator, governance_policy.value(), 900, 8));
+
+    ValidatorSet governed_set {
+        .network_id = network.id(),
+        .epoch      = 6,
+    };
+    for (std::size_t index = 0; index < operators.size(); ++index) {
+        const auto record = make_validator_record(network.id(),
+                                                  6,
+                                                  operators[index],
+                                                  consensus_keys[index],
+                                                  "node-" + std::to_string(index),
+                                                  0);
+        governed_set.validators.push_back(record.value());
+    }
+    const auto governed_action =
+        governed_validator_set_action_hash(governed_set, change.registry_document_hash, change.operators);
+    const auto governed_authorization =
+        authorize_action(governance_policy.value(),
+                         10,
+                         governed_action,
+                         { governance_keys[0], governance_keys[1], governance_keys[2] });
+    const auto governed_view = ValidatorSetView::create_governed(governed_set,
+                                                                 change.registry_document_hash,
+                                                                 change.operators,
+                                                                 governance_policy.value(),
+                                                                 governed_authorization.value(),
+                                                                 10);
+    check("multisig creates a governed validator set without a network-actor signature",
+          governed_view.has_value() && governed_view.value().active().size() == 7);
+    check("governed validator set rejects a repeated authorization sequence",
+          !ValidatorSetView::create_governed(governed_set,
+                                             change.registry_document_hash,
+                                             change.operators,
+                                             governance_policy.value(),
+                                             governed_authorization.value(),
+                                             11)
+               .has_value());
+
+    auto transition_change                    = change;
+    transition_change.next_validator_set_hash = hash_validator_set(governed_set);
+    transition_change.authorization =
+        authorize_action(governance_policy.value(),
+                         11,
+                         epoch_change_action_hash(transition_change),
+                         { governance_keys[0], governance_keys[1], governance_keys[2] })
+            .value();
+    const auto transitioned_view = ValidatorSetView::create_epoch_transition(governed_set,
+                                                                             transition_change,
+                                                                             governance_policy.value(),
+                                                                             900,
+                                                                             11);
+    check("finalized epoch data creates the next seven-validator view",
+          transitioned_view.has_value() && transitioned_view.value().document().epoch == 6);
+
+    auto               recovery_keys   = make_keys(5);
+    const auto         recovery_policy = make_multisig_policy(network.id(), 4, public_keys(recovery_keys));
+    RecoveryDocumentV1 recovery {
+        .network_id                = network.id(),
+        .recovery_sequence         = 3,
+        .finalized_height          = 700,
+        .finalized_checkpoint_hash = "checkpoint-700",
+        .next_validator_set_hash   = "recovery-set",
+        .registry_document_hash    = "recovery-registry",
+    };
+    const auto recovery_authorization =
+        authorize_action(recovery_policy.value(),
+                         3,
+                         recovery_action_hash(recovery),
+                         { recovery_keys[0], recovery_keys[1], recovery_keys[2], recovery_keys[3] });
+    recovery.authorization = recovery_authorization.value();
+    check("four of five recovery document verifies",
+          verify_recovery_document(recovery, recovery_policy.value(), 3, 700, "checkpoint-700"));
+    check("recovery cannot move from another checkpoint",
+          !verify_recovery_document(recovery, recovery_policy.value(), 3, 700, "checkpoint-699"));
+
+    StateCommitmentV2 commitment {
+        .network_id                = network.id(),
+        .epoch                     = 4,
+        .height                    = 700,
+        .previous_state_commitment = "previous",
+        .section_root              = "sections",
+        .account_state_root        = "accounts",
+        .contract_state_root       = "contracts",
+        .token_registry_root       = "tokens",
+        .validator_set_hash        = "validators",
+    };
+    const auto commitment_hash    = hash_state_commitment(commitment);
+    commitment.account_state_root = "changed";
+    check("state commitment binds all state roots", commitment_hash != hash_state_commitment(commitment));
+
+    std::printf("CONSENSUS PROTOCOL: %d pass, %d fail\n", passed, failed);
+    return failed == 0 ? 0 : 1;
+}

--- a/tests/consensus_test.cpp
+++ b/tests/consensus_test.cpp
@@ -8,6 +8,7 @@
 #include "consensus/peer_authenticator.h"
 #include "consensus/shadow_consensus.h"
 #include "utils/exc_utils.h"
+#include "utils/exc_utils_base64.h"
 
 namespace {
     using namespace ExtraChain::Consensus;
@@ -186,6 +187,7 @@ int main() {
         const auto observer = ShadowConsensus::load(observer_directory, fixture.governance.id());
         check("observer loads without a private validator key",
               observer.has_value() && !observer.value()->engine().identity().has_value());
+        Fixture    finality_fixture(7);
         const auto finality_directory = root / "finality-validator";
         check("finality configuration is written atomically",
               ShadowConsensus::write_configuration(finality_directory,
@@ -199,6 +201,40 @@ int main() {
                                                                           .activation_height      = 1,
                                                                           .activation_dag_section = 0 })
                    .has_value());
+        check("finality receives the signed validator set",
+              ShadowConsensus::write_validator_set(finality_directory, finality_fixture.validator_set)
+                  .has_value());
+        check("finality cannot load without a governed activation",
+              !ShadowConsensus::load(finality_directory, finality_fixture.governance.id()).has_value());
+        std::vector<KeyPrivate>  governance_keys(5);
+        std::vector<std::string> governance_public_keys;
+        for (auto& key : governance_keys) {
+            key.generate_random();
+            governance_public_keys.push_back(Utils::to_base64(key.public_key()));
+        }
+        const auto governance_policy =
+            make_multisig_policy(finality_fixture.governance.id(), GovernanceThreshold, governance_public_keys);
+        check("governance policy is written atomically",
+              governance_policy.has_value()
+                  && ShadowConsensus::write_governance_policy(finality_directory, governance_policy.value())
+                         .has_value());
+        ActivationManifestV1 manifest {
+            .network_id             = finality_fixture.governance.id(),
+            .activation_height      = 10,
+            .activation_dag_section = 200,
+            .validator_set_hash     = finality_fixture.view.hash(),
+        };
+        const auto manifest_authorization =
+            authorize_action(governance_policy.value(),
+                             1,
+                             activation_action_hash(manifest),
+                             { governance_keys[0], governance_keys[1], governance_keys[2] });
+        manifest.authorization = manifest_authorization.value();
+        check("activation manifest is written atomically",
+              ShadowConsensus::write_activation_manifest(finality_directory, manifest, governance_policy.value())
+                  .has_value());
+        const auto finality = ShadowConsensus::load(finality_directory, finality_fixture.governance.id());
+        check("finality loads only after governed activation", finality.has_value());
     }
 
     std::vector<std::unique_ptr<ConsensusEngine>> engines;
@@ -310,6 +346,18 @@ int main() {
     check("finality creates a portable three-chain proof",
           proofs.has_value() && proofs.value().size() == 1
               && engines.front()->verify_finality_proof(proofs.value().front()));
+    const auto inclusion = engines.front()->transaction_inclusion_proof("transaction-1");
+    check("finalized transaction has a Merkle inclusion proof",
+          inclusion.has_value() && inclusion.value().has_value()
+              && engines.front()->verify_transaction_inclusion_proof(inclusion.value().value()));
+    if (inclusion.has_value() && inclusion.value().has_value()) {
+        auto changed_inclusion             = inclusion.value().value();
+        changed_inclusion.transaction_hash = "transaction-changed";
+        check("changed transaction inclusion proof is rejected",
+              !engines.front()->verify_transaction_inclusion_proof(changed_inclusion));
+    } else {
+        check("changed transaction inclusion proof is rejected", false);
+    }
     if (proofs.has_value() && !proofs.value().empty()) {
         auto changed_proof                             = proofs.value().front();
         changed_proof.decision_certificate.header_hash = "changed-header";

--- a/tests/dag_recovery.cpp
+++ b/tests/dag_recovery.cpp
@@ -7,6 +7,7 @@
 #include "chain/actor.h"
 #include "chain/dag.h"
 #include "chain/dag_recovery.h"
+#include "consensus/consensus_protocol.h"
 #include "core/extrachain_node.h"
 #include "managers/account_controller.h"
 #include "network/responder.h"
@@ -129,13 +130,31 @@ int main() {
             },
         .batch = shadow_batch.value().manifest,
     };
-    shadow_batch.value().header_hash = ExtraChain::Consensus::hash_header(shadow_proposal.header);
+    shadow_batch.value().header_hash  = ExtraChain::Consensus::hash_header(shadow_proposal.header);
+    const auto calculated_shadow_root = node->dag()->shadow_batch_section_root(shadow_batch.value());
+    TEST_REQUIRE(calculated_shadow_root.has_value());
+    TEST_REQUIRE_EQ(calculated_shadow_root.value(), control_20_before);
     const auto shadow_validation =
         node->dag()->validate_shadow_batch(shadow_proposal, shadow_batch.value(), 16ULL * 1024ULL * 1024ULL);
     TEST_REQUIRE_MESSAGE(shadow_validation.has_value(),
                          shadow_validation.has_value()
                              ? std::string {}
                              : std::to_string(std::to_underlying(shadow_validation.error())));
+    WireFormat::Scope speculative_scope(WireFormat::Mode::Canonical);
+    const auto        speculative_parent =
+        Json::serialize(Section { .id = SectionId(60), .transactions = {}, .control = std::nullopt });
+    const auto speculative_empty_batch =
+        node->dag()->build_shadow_intent_batch(SectionId(61),
+                                               SectionId(80),
+                                               2,
+                                               std::vector<ExtraChain::Consensus::IntentEnvelope> {},
+                                               {},
+                                               speculative_parent,
+                                               "speculative-parent-root");
+    TEST_REQUIRE(speculative_empty_batch.has_value());
+    TEST_REQUIRE(speculative_empty_batch.value().manifest.transaction_hashes.empty());
+    TEST_REQUIRE_EQ(speculative_empty_batch.value().manifest.previous_section_root, "speculative-parent-root");
+    TEST_REQUIRE(node->dag()->shadow_batch_section_root(speculative_empty_batch.value()).has_value());
     auto corrupted_shadow_batch = shadow_batch.value();
     corrupted_shadow_batch.sections.front().second.push_back('x');
     TEST_REQUIRE(!node->dag()


### PR DESCRIPTION
## What changed

- Add the Shadow finality gateway and controlled activation.
- Add signed transaction intents, durable receipts, and deterministic materialization.
- Add validator epoch changes, inclusion proofs, and light-client state.
- Add durable recovery, protocol tests, a formal Quint model, and its CI check.

## Why

Shadow needs a verified final order for DAG data. It must keep safety after a restart and during a validator-set change.

## Validation

- Core CTest: 10 of 10 passed in two consecutive runs.
- Consensus tests: 142 passed.
- Protocol tests: 62 passed.
- Network tests: 651 passed.
- Quint: nine invariants passed with 100,000 samples and 40 steps per invariant.
- Combined four-node DAG and ExDFS stand passed without section divergence.
- Long benchmark: 26.544 heights per second, 108.7% above the original baseline.

## Activation limits

Production Finality remains disabled by default. It still requires state-root integration, emergency recovery automation, trusted light-client bootstrap distribution, and a long voting-committee soak test.
